### PR TITLE
Add reproducible builds with nix in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,5 @@
 .git/
 fly.toml
+bin
+result
+target

--- a/.github/workflows/reproducible-builds.yml
+++ b/.github/workflows/reproducible-builds.yml
@@ -1,0 +1,59 @@
+name: Reproducible Build
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - nix
+    tags:
+      - v?[0-9]+.[0-9]+.[0-9]+*
+
+#concurrency:
+#  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+#  cancel-in-progress: true
+
+env:
+  TELEPORT_SHA256: a961a7faa428a8535f7d1ed8056ad393537f5dd78b3194f94da4210b1dc5cd22
+
+jobs:
+  nix-teleport:
+    name: Build teleport with nix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - name: Build
+        run: nix build .
+      - name: Rebuild
+        run: nix build --rebuild
+      - name: sha256sum output
+        run: sha256sum result/bin/teleport
+      - name: sha256sum check
+        run: |
+          echo "$TELEPORT_SHA256 *result/bin/teleport" | sha256sum --strict --check
+      - run: nix flake check
+      - run: nix flake metadata
+      - run: nix flake show
+      - run: ls -l result
+
+  docker-nix-teleport:
+    name: Build teleport with nix in docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build
+        uses: docker/build-push-action@v6
+        with:
+          target: nix-build-output
+          allow: security.insecure
+          push: false
+          tags: sbellem/teleport
+          outputs: type=local,dest=bin
+      - name: sha256sum output
+        run: sha256sum bin/teleport
+      - name: sha256sum check
+        run: |
+          echo "$TELEPORT_SHA256 *bin/teleport" | sha256sum --strict --check

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ auth2fa.csv
 redeem.json
 user_infos.json
 save_dir/shared/users/*.user
+result
+bin
+private.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if 1.0.0",
- "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -64,7 +63,8 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 [[package]]
 name = "alloy"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/alloy#1decf94c862bb43ce4c814e3a0d48a649da14fdd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056f2c01b2aed86e15b43c47d109bfc8b82553dc34e66452875e51247ec31ab2"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -87,10 +87,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.36"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94c225801d42099570d0674701dddd4142f0ef715282aeb5985042e2ec962df7"
+checksum = "dca4a1469a3e572e9ba362920ff145f5d0a00a3e71a64ddcb4a3659cf64c76a7"
 dependencies = [
+ "alloy-primitives",
  "num_enum",
  "strum",
 ]
@@ -98,7 +99,8 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/alloy#1decf94c862bb43ce4c814e3a0d48a649da14fdd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "705687d5bfd019fee57cf9e206b27b30a9a9617535d5590a02b171e813208f8e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -113,7 +115,8 @@ dependencies = [
 [[package]]
 name = "alloy-contract"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/alloy#1decf94c862bb43ce4c814e3a0d48a649da14fdd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "917f7d12cf3971dc8c11c9972f732b35ccb9aaaf5f28f2f87e9e6523bee3a8ad"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -132,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "0.8.7"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb750349efda145ca6aada68d0336067f7f364d7d44ef09e2cf000b040c5e99"
+checksum = "5cce174ca699ddee3bfb2ec1fbd99ad7efd05eca20c5c888d8320db41f7e8f04"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -145,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.8.7"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f95d76a38cae906fd394a5afb0736aaceee5432efe76addfd71048e623e208af"
+checksum = "5647fce5a168f9630f935bf7821c4207b1755184edaeba783cb4e11d35058484"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -186,7 +189,8 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/alloy#1decf94c862bb43ce4c814e3a0d48a649da14fdd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ffb906284a1e1f63c4607da2068c8197458a352d0b3e9796e67353d72a9be85"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -203,7 +207,8 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/alloy#1decf94c862bb43ce4c814e3a0d48a649da14fdd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8429cf4554eed9b40feec7f4451113e76596086447550275e3def933faf47ce3"
 dependencies = [
  "alloy-primitives",
  "alloy-serde",
@@ -212,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.8.7"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c66eec1acdd96b39b995b8f5ee5239bc0c871d62c527ae1ac9fd1d7fecd455"
+checksum = "4b5671117c38b1c2306891f97ad3828d85487087f54ebe2c7591a055ea5bcea7"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -225,7 +230,8 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/alloy#1decf94c862bb43ce4c814e3a0d48a649da14fdd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fa8a1a3c4cbd221f2b8e3693aeb328fca79a757fe556ed08e47bbbc2a70db7"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -238,7 +244,8 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/alloy#1decf94c862bb43ce4c814e3a0d48a649da14fdd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85fa23a6a9d612b52e402c995f2d582c25165ec03ac6edf64c861a76bc5b87cd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -258,7 +265,8 @@ dependencies = [
 [[package]]
 name = "alloy-network-primitives"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/alloy#1decf94c862bb43ce4c814e3a0d48a649da14fdd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "801492711d4392b2ccf5fc0bc69e299fa1aab15167d74dcaa9aab96a54f684bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -269,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.7"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb848c43f6b06ae3de2e4a67496cbbabd78ae87db0f1248934f15d76192c6a"
+checksum = "c71738eb20c42c5fb149571e76536a0f309d142f3957c28791662b96baf77a3d"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -298,7 +306,8 @@ dependencies = [
 [[package]]
 name = "alloy-provider"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/alloy#1decf94c862bb43ce4c814e3a0d48a649da14fdd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcfaa4ffec0af04e3555686b8aacbcdf7d13638133a0672749209069750f78a6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -321,23 +330,21 @@ dependencies = [
  "futures",
  "futures-utils-wasm",
  "lru",
- "parking_lot",
  "pin-project",
  "reqwest 0.12.8",
- "schnellru",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
  "tracing",
  "url",
- "wasmtimer",
 ]
 
 [[package]]
 name = "alloy-pubsub"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/alloy#1decf94c862bb43ce4c814e3a0d48a649da14fdd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f32cef487122ae75c91eb50154c70801d71fabdb976fec6c49e0af5e6486ab15"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -354,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26154390b1d205a4a7ac7352aa2eb4f81f391399d4e2f546fb81a2f8bb383f62"
+checksum = "da0822426598f95e45dd1ea32a738dac057529a709ee645fcc516ffa4cbde08f"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -365,19 +372,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d0f2d905ebd295e7effec65e5f6868d153936130ae718352771de3e7d03c75c"
+checksum = "2b09cae092c27b6f1bde952653a22708691802e57bfef4a2973b80bea21efd3f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "alloy-rpc-client"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/alloy#1decf94c862bb43ce4c814e3a0d48a649da14fdd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "370143ed581aace6e663342d21d209c6b2e34ee6142f7d6675adb518deeaf0dc"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -396,13 +404,13 @@ dependencies = [
  "tower 0.5.1",
  "tracing",
  "url",
- "wasmtimer",
 ]
 
 [[package]]
 name = "alloy-rpc-types"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/alloy#1decf94c862bb43ce4c814e3a0d48a649da14fdd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ffc534b7919e18f35e3aa1f507b6f3d9d92ec298463a9f6beaac112809d8d06"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -414,7 +422,8 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-engine"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/alloy#1decf94c862bb43ce4c814e3a0d48a649da14fdd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0285c4c09f838ab830048b780d7f4a4f460f309aa1194bb049843309524c64c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -427,7 +436,8 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-eth"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/alloy#1decf94c862bb43ce4c814e3a0d48a649da14fdd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413f4aa3ccf2c3e4234a047c5fa4727916d7daf25a89f9b765df0ba09784fd87"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -445,7 +455,8 @@ dependencies = [
 [[package]]
 name = "alloy-serde"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/alloy#1decf94c862bb43ce4c814e3a0d48a649da14fdd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dff0ab1cdd43ca001e324dc27ee0e8606bd2161d6623c63e0e0b8c4dfc13600"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -455,7 +466,8 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/alloy#1decf94c862bb43ce4c814e3a0d48a649da14fdd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd4e0ad79c81a27ca659be5d176ca12399141659fef2bcbfdc848da478f4504"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -468,7 +480,8 @@ dependencies = [
 [[package]]
 name = "alloy-signer-local"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/alloy#1decf94c862bb43ce4c814e3a0d48a649da14fdd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494e0a256f3e99f2426f994bcd1be312c02cb8f88260088dacb33a8b8936475f"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -484,23 +497,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.7"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "661c516eb1fa3294cc7f2fb8955b3b609d639c282ac81a4eedb14d3046db503a"
+checksum = "b0900b83f4ee1f45c640ceee596afbc118051921b9438fdb5a3175c1a7e05f8b"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.7"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecbabb8fc3d75a0c2cea5215be22e7a267e3efde835b0f2a8922f5e3f5d47683"
+checksum = "a41b1e78dde06b5e12e6702fa8c1d30621bf07728ba75b801fb801c9c6a0ba10"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -510,16 +523,16 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
  "syn-solidity",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.7"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16517f2af03064485150d89746b8ffdcdbc9b6eeb3d536fb66efd7c2846fbc75"
+checksum = "91dc311a561a306664393407b88d3e53ae58581624128afd8a15faa5de3627dc"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -528,15 +541,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.79",
+ "syn 2.0.85",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.8.7"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c07ebb0c1674ff8cbb08378d7c2e0e27919d2a2dae07ad3bca26174deda8d389"
+checksum = "45d1fbee9e698f3ba176b6e7a145f4aefe6d2b746b611e8bb246fe11a0e9f6c4"
 dependencies = [
  "serde",
  "winnow",
@@ -544,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.7"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e448d879903624863f608c552d10efb0e0905ddbee98b0049412799911eb062"
+checksum = "086f41bc6ebcd8cb15f38ba20e47be38dd03692149681ce8061c35d960dbf850"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -558,7 +571,8 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/alloy#1decf94c862bb43ce4c814e3a0d48a649da14fdd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac3e97dad3d31770db0fc89bd6a63b789fbae78963086733f960cf32c483904"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
@@ -571,13 +585,13 @@ dependencies = [
  "tower 0.5.1",
  "tracing",
  "url",
- "wasmtimer",
 ]
 
 [[package]]
 name = "alloy-transport-http"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/alloy#1decf94c862bb43ce4c814e3a0d48a649da14fdd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b367dcccada5b28987c2296717ee04b9a5637aacd78eacb1726ef211678b5212"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -591,7 +605,8 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ipc"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/alloy#1decf94c862bb43ce4c814e3a0d48a649da14fdd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90cf9cde7f2fce617da52768ee28f522264b282d148384a4ca0ea85af04fa3a"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -609,18 +624,18 @@ dependencies = [
 [[package]]
 name = "alloy-transport-ws"
 version = "0.4.2"
-source = "git+https://github.com/alloy-rs/alloy#1decf94c862bb43ce4c814e3a0d48a649da14fdd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7153b88690de6a50bba81c11e1d706bc41dbb90126d607404d60b763f6a3947f"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "futures",
  "http 1.1.0",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "serde_json",
  "tokio",
  "tokio-tungstenite",
  "tracing",
- "wasmtimer",
  "ws_stream_wasm",
 ]
 
@@ -641,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -656,43 +671,43 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 
 [[package]]
 name = "arc-swap"
@@ -856,7 +871,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -893,7 +908,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -904,7 +919,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -932,7 +947,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -955,7 +970,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -1028,7 +1043,7 @@ checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1043,7 +1058,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
@@ -1250,9 +1265,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 dependencies = [
  "serde",
 ]
@@ -1274,9 +1289,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.28"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "shlex",
 ]
@@ -1361,9 +1376,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "const-hex"
@@ -1548,7 +1563,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1559,7 +1574,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1630,7 +1645,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
  "unicode-xid",
 ]
 
@@ -1714,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1957,7 +1972,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2097,12 +2112,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
 name = "hashbrown"
@@ -2285,9 +2294,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.30"
+version = "0.14.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2309,9 +2318,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2335,7 +2344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -2349,7 +2358,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2368,7 +2377,7 @@ dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2516,9 +2525,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2564,15 +2573,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "3bda4c6077b0b08da2c48b172195795498381a7c8988c9e6212a6c55c5b9bd70"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -2815,7 +2824,7 @@ checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2901,9 +2910,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.66"
+version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if 1.0.0",
@@ -2922,7 +2931,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2933,9 +2942,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.103"
+version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
@@ -3016,9 +3025,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.13"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbef9d1d47087a895abd220ed25eb4ad973a5e26f6a4367b038c25e28dfc2d9"
+checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
  "thiserror",
@@ -3055,29 +3064,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -3193,14 +3202,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -3364,9 +3373,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3405,7 +3414,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
@@ -3447,7 +3456,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
@@ -3610,7 +3619,7 @@ checksum = "73a3b7a697592aa63f7d26e845990e32f618e47927192aec89f4e54c2c2685f1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3689,9 +3698,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.14"
+version = "0.23.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
+checksum = "5fbb44d7acc4e873d613422379f69f237a1b141928c02f6bc6ccfddddc2d7993"
 dependencies = [
  "log",
  "once_cell",
@@ -3722,9 +3731,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-webpki"
@@ -3749,9 +3758,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "rusty-fork"
@@ -3778,17 +3787,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
 dependencies = [
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "schnellru"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a8ef13a93c54d20580de1e5c413e624e53121d42fc7e2c11d10ef7f8b02367"
-dependencies = [
- "ahash",
- "cfg-if 1.0.0",
- "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -3886,29 +3884,29 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa",
  "memchr",
@@ -3976,7 +3974,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4154,7 +4152,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4176,9 +4174,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4187,14 +4185,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.7"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20e7b52ad118b2153644eea95c6fc740b6c1555b2344fdab763fc9de4075f665"
+checksum = "9d5e0c2ea8db64b2898b62ea2fbd60204ca95e0b2c6bdf53ff768bbe916fbe4d"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4313,22 +4311,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4408,9 +4406,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4431,7 +4429,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4512,7 +4510,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "rustls-pki-types",
  "tokio",
 ]
@@ -4537,7 +4535,7 @@ checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -4663,7 +4661,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4694,7 +4692,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "rustls-pki-types",
  "sha1",
  "thiserror",
@@ -4733,12 +4731,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
+checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 
 [[package]]
 name = "unicode-bidi"
@@ -4795,7 +4790,7 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "rustls-pki-types",
  "url",
  "webpki-roots 0.26.6",
@@ -4826,9 +4821,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom 0.2.15",
 ]
@@ -4895,9 +4890,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
@@ -4906,24 +4901,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -4933,9 +4928,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4943,28 +4938,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -4974,24 +4969,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtimer"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f656cd8858a5164932d8a90f936700860976ec21eb00e0fe2aa8cab13f6b4cf"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot",
- "pin-utils",
- "slab",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5326,7 +5307,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5346,5 +5327,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,9 @@ url = "2.5.1"
 serde_urlencoded = "0.7.1"
 serde_qs = "0.13.0"
 axum = { version = "0.7.5", features = ["macros"] }
-alloy = { git = "https://github.com/alloy-rs/alloy", version = "^0.4.2", features = [
+alloy = { version = "0.4.2", features = [
     "full",
     "signer-mnemonic"
-
 ] }
 
 futures-util = "0.3"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,73 @@
+# syntax=docker/dockerfile:1.3-labs
+#
+# References
+# ----------
+# https://docs.docker.com/reference/cli/docker/buildx/build/#allow
+# https://docs.docker.com/reference/dockerfile/#run---security
+FROM  nixpkgs/cachix-flakes AS nix-build
+WORKDIR /usr/src/app
+COPY flake.lock flake.nix Cargo.lock Cargo.toml rust-toolchain .
+COPY src src
+RUN rm src/bin/redeem.rs
+COPY abi abi
+COPY templates templates
+RUN --security=insecure nix build --sandbox --show-trace
+
+FROM scratch as nix-build-output
+COPY --from=nix-build /usr/src/app/result/bin/teleport .
+
+
+FROM rust:1.79.0 AS chef
+RUN cargo install cargo-chef
+WORKDIR /usr/src/app
+
+FROM chef AS planner
+RUN apt-get update && apt-get install -y \
+            libssl-dev \
+            pkg-config \
+        && rm -rf /var/lib/apt/lists/*
+COPY Cargo.lock Cargo.toml teleport.env .
+COPY src src
+RUN rm src/bin/redeem.rs
+COPY abi abi
+COPY templates templates
+RUN cargo chef prepare  --recipe-path recipe.json
+
+FROM chef AS cargo-build
+COPY --from=planner /usr/src/app/recipe.json recipe.json
+# Build dependencies - this is the caching Docker layer!
+RUN cargo chef cook --release --recipe-path recipe.json
+# Build application
+COPY Cargo.lock Cargo.toml teleport.env .
+COPY src src
+RUN rm src/bin/redeem.rs
+COPY abi abi
+COPY templates templates
+RUN cargo build --release
+
+
 FROM gramineproject/gramine:1.7-jammy AS builder
 
-RUN apt-get update && apt-get install -y jq build-essential libclang-dev
+ARG nix=1
+ARG sgx=1
+ENV NIX ${nix}
+ENV SGX ${sgx}
+ENV RA_TYPE dcap
+
+RUN apt-get update && apt-get install -y \
+            build-essential \
+            jq \
+            libclang-dev \
+        && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workdir
 
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
-RUN rustup toolchain install 1.75.0
-
-RUN gramine-sgx-gen-private-key
-
-RUN apt-get install -y pkg-config libssl-dev
-
-# Build just the dependencies (shorcut)
-COPY Cargo.lock Cargo.toml ./
-RUN mkdir src && echo "fn main() {}" > src/main.rs
-RUN cargo build --release
-RUN rm -r src
-
-# Now add our actual source
-COPY teleport.env Makefile ./
-COPY src ./src
-RUN rm src/bin/redeem.rs
-COPY abi ./abi
-COPY templates ./templates
-
-# Build with rust
-RUN cargo build --release
+COPY --from=nix-build /usr/src/app/result/bin/teleport result/bin/teleport
+COPY --from=cargo-build /usr/src/app/target/release/teleport target/release/teleport
 
 # Make and sign the gramine manifest
-COPY exex.manifest.template ./
-RUN make SGX=1 RA_TYPE=dcap
+RUN gramine-sgx-gen-private-key
+COPY exex.manifest.template teleport.env Makefile ./
+RUN make
 
 CMD [ "gramine-sgx-sigstruct-view exex.sig" ]

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,12 @@
 
 ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
+ifeq ($(NIX),1)
+SELF_EXE = result/bin/teleport
+else
 SELF_EXE = target/release/teleport
+endif
+
 DB_FILE = target/release/main.db
 
 .PHONY: all
@@ -23,9 +28,11 @@ endif
 # to Make, as compiling in debug mode results in an order of magnitude's difference in
 # performance that makes testing by running a benchmark with ab painful. The primary goal
 # of the DEBUG setting is to control Gramine's loglevel.
+ifeq ($(NIX),)
 -include $(SELF_EXE).d # See also: .cargo/config.toml
 $(SELF_EXE): Cargo.toml
 	cargo build --release
+endif
 
 exex.manifest: exex.manifest.template
 	gramine-manifest \

--- a/REPRO_BUILDS.md
+++ b/REPRO_BUILDS.md
@@ -1,0 +1,90 @@
+# Reproducible Builds
+Notes on building teleport in a reproducible manner, with Nix.
+
+## Prerequisites
+* Docker Engine with the Compose plugin (`>= 2.27.1`). ([Installation
+  instructions](https://docs.docker.com/engine/install/).) Note that the version of
+  Compose must be 2.27.1 or higher as
+  [entitlements](https://docs.docker.com/reference/compose-file/build/#entitlements) are
+  needed.
+
+*Optional*:
+* [Nix](https://zero-to-nix.com/) with flakes enabled.
+
+
+## Build with Docker
+In order to benefit from Nix's sandbox environment in Docker, we need to [allow
+entitlements](https://docs.docker.com/reference/cli/docker/buildx/build/#allow).
+
+```shell
+docker buildx create --use --name insecure-builder --buildkitd-flags '--allow-insecure-entitlement security.insecure'
+```
+
+The teleport binary can now be built with Nix, in Docker. For convenience, we show the
+necessary minimal `Dockerfile` here:
+
+```dockerfile
+# syntax=docker/dockerfile:1.3-labs
+FROM  nixpkgs/cachix-flakes AS nix-build
+WORKDIR /usr/src/app
+COPY . .
+RUN --security=insecure nix build --sandbox --show-trace
+
+FROM scratch as nix-build-output
+COPY --from=nix-build /usr/src/app/result/bin/teleport .
+```
+
+Build teleport with Nix in Docker, and output the binary to the host under
+`bin/docker/`.
+
+```shell
+docker buildx build \
+  --allow security.insecure \
+  --tag nix-teleport \
+  --target nix-build-output \
+  --output type=local,dest=bin/docker/ .
+```
+
+
+## Build and Develop with Nix
+See [Zero to Nix](https://zero-to-nix.com/).
+
+1. [Installing nix](https://zero-to-nix.com/start/install)
+
+2. [Check installation](https://zero-to-nix.com/start/nix-run)
+  ```shell
+  echo "Hello Nix" | nix run "https://flakehub.com/f/NixOS/nixpkgs/*#ponysay"
+  ```
+
+3. Building teleport with `nix`
+  ```shell
+  nix build --out-link bin/nix/
+  ```
+  Binary will be under `result/bin/`
+
+  It's possible to set a different output directory, e.g.:
+  ```shell
+  nix build --out-link bin/nix/
+  ```
+
+4. Development environment with `nix develop` -- start a development shell with:
+  ```shell
+  nix develop
+  ```
+  You should now have a nix-based environment. For instance, try:
+
+  ```shell
+  type cargo
+  #cargo is /nix/store/mpkddnv8934wrg0jb0lh38d16pl17ss3-rust-default-1.82.0/bin/cargo
+  ```
+
+
+## Documentation
+[Building Rust with Nix](https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/rust.section.md#importing-a-cargolock-file-importing-a-cargolock-file)
+
+[oxalica's Rust overlay](https://github.com/oxalica/rust-overlay)
+
+## CI
+https://github.com/DeterminateSystems/nix-installer-action?tab=readme-ov-file
+
+## Troubleshooting

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
 
   teleport:
@@ -7,6 +5,8 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile
+      entitlements:
+        - security.insecure
       # args:
     environment:
       - SGX=1

--- a/exex.sgx
+++ b/exex.sgx
@@ -6,7 +6,6 @@ log_level = "error"
 argv = [
     "target/release/teleport",
 ]
-entrypoint = "file:/usr/lib/x86_64-linux-gnu/gramine/libsysdb.so"
 uid = 65534
 gid = 65534
 
@@ -37,11 +36,27 @@ passthrough = true
 [loader.env.DATABASE_URL]
 passthrough = true
 
+[loader.env.BOOTSTRAP]
+passthrough = true
+
+[loader.env.ONBOARD]
+passthrough = true
+
+[loader.entrypoint]
+uri = "file:/usr/lib/x86_64-linux-gnu/gramine/libsysdb.so"
+sha256 = "8fb2d369e5d67d4d34100464e1b052d18a421860409f3aeef87a0ed9655a85ac"
+
 [[fs.mounts]]
 type = "encrypted"
-path = "/root/save/"
-uri = "file:save_dir/"
+path = "/root/save"
+uri = "file:save_dir/sealed"
 key_name = "_sgx_mrenclave"
+
+[[fs.mounts]]
+type = "encrypted"
+path = "/root/shared"
+uri = "file:save_dir/shared"
+key_name = "shared"
 
 [[fs.mounts]]
 path = "/teleport.env"
@@ -81,7 +96,7 @@ remote_attestation = "dcap"
 allowed_files = [
     "file:untrustedhost",
 ]
-max_threads = 32
+max_threads = 48
 isvprodid = 0
 isvsvn = 0
 enable_stats = false
@@ -2638,15 +2653,15 @@ sha256 = "54ef601588ffd6747497ebf2d8abc97329dcc89ffd995c7b6ef82cdae4b4dd0a"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/direct/libpal.so"
-sha256 = "8edccb9883e04363034ea837d6aa7f38ebffde59c30508666cc8fdf8d23bf291"
+sha256 = "ea140cc8d9caad6ba736b892ddc580444a091a37063d3db501caea4541af8025"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/direct/loader"
-sha256 = "8edccb9883e04363034ea837d6aa7f38ebffde59c30508666cc8fdf8d23bf291"
+sha256 = "ea140cc8d9caad6ba736b892ddc580444a091a37063d3db501caea4541af8025"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/libsysdb.so"
-sha256 = "a9274eba09232700a62b8d604624024c9acea52cca4dc8350fa78ed6fb1e575a"
+sha256 = "8fb2d369e5d67d4d34100464e1b052d18a421860409f3aeef87a0ed9655a85ac"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/crt1.o"
@@ -2662,11 +2677,11 @@ sha256 = "df37c23206d280925216df48eb2d114b283fb28c116e952afe907250e0b89faa"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/ld-linux-x86-64.so.2"
-sha256 = "878d4bd8df7c99e46b5655f176862a1efe97f807256ab44a0f23c05cd2e316d9"
+sha256 = "c5abc02506c12caae024d2fc27af3a1da44934e7f4f8241350f7a476caba25f3"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/ld.so"
-sha256 = "878d4bd8df7c99e46b5655f176862a1efe97f807256ab44a0f23c05cd2e316d9"
+sha256 = "c5abc02506c12caae024d2fc27af3a1da44934e7f4f8241350f7a476caba25f3"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libanl.so"
@@ -2678,11 +2693,11 @@ sha256 = "857e6fac284a297b573489d34e4d6ab2380da96a9df89611cfa7e05a243cc11c"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libc.so"
-sha256 = "b0060a43c7754d56bb91807cd62f724d77883c1009c0d18830071ec2ea074785"
+sha256 = "e282928e943bbde9b4dbabff2d27b332c27a3762f1925d2dc703c17594397b80"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libc.so.6"
-sha256 = "b0060a43c7754d56bb91807cd62f724d77883c1009c0d18830071ec2ea074785"
+sha256 = "e282928e943bbde9b4dbabff2d27b332c27a3762f1925d2dc703c17594397b80"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libdl.so"
@@ -2694,47 +2709,47 @@ sha256 = "b9717d7c65be7e92f9353a2daae1dd89a417a7907398aefd024c77e94920e6c8"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libm.so"
-sha256 = "27abaefc5a51076014908e0ebc131a196577200210254614777bd8d1836f2b71"
+sha256 = "5713649f9c67811bc7a9bb33b6fc545b6b48ac3af023bdbd4a5ef73c38cad2aa"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libm.so.6"
-sha256 = "27abaefc5a51076014908e0ebc131a196577200210254614777bd8d1836f2b71"
+sha256 = "5713649f9c67811bc7a9bb33b6fc545b6b48ac3af023bdbd4a5ef73c38cad2aa"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libmbedcrypto_gramine.a"
-sha256 = "31d510cb178921a4c95ac7fc46aa03a34bed145cd6e04998e0c6bb5abad3d5bc"
+sha256 = "598d1f16c625011ea2e0c262865ec0c895c17fc8718615b0fa4d21998cae9233"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libmbedcrypto_gramine.so"
-sha256 = "ab5121fe816d488acb2cd562687785b6108bf381d663c3ccda09ad1128376a53"
+sha256 = "752698bbeec2242538cab4722e503af6adc877338338493eb3bbf3992475de96"
 
 [[sgx.trusted_files]]
-uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libmbedcrypto_gramine.so.15"
-sha256 = "ab5121fe816d488acb2cd562687785b6108bf381d663c3ccda09ad1128376a53"
+uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libmbedcrypto_gramine.so.16"
+sha256 = "752698bbeec2242538cab4722e503af6adc877338338493eb3bbf3992475de96"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libmbedtls_gramine.a"
-sha256 = "65f0b15b8b6746eff2d6744d31002e920175c671b37556b2f63f8ff0649e58a8"
+sha256 = "350f641c4939e56c5ad69627bc7e2ad59bd1efb74a7006a25af6e56037e7fa42"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libmbedtls_gramine.so"
-sha256 = "4117f196176c05097ac3091c81ef64b44e5c01ec494c5ce88713ec4c94c459b8"
+sha256 = "00aa2b10123dbc05d955448c404a0f013cfc9de06fb02751048c4b6cf32af290"
 
 [[sgx.trusted_files]]
-uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libmbedtls_gramine.so.20"
-sha256 = "4117f196176c05097ac3091c81ef64b44e5c01ec494c5ce88713ec4c94c459b8"
+uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libmbedtls_gramine.so.21"
+sha256 = "00aa2b10123dbc05d955448c404a0f013cfc9de06fb02751048c4b6cf32af290"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libmbedx509_gramine.a"
-sha256 = "8b7703995327a6bce30a64c801d47fe53e98c1c20f8888bfacc676c2b624eec6"
+sha256 = "00c1bc2f982f3fa7ed5b14d2c1fe4738097f9bb15dd714d01636de94ffbb116a"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libmbedx509_gramine.so"
-sha256 = "edd891d4fa3ea03e941877b52476e2570cf010eda81ca5f3b5e283205e39aeee"
+sha256 = "c2c15bc12b8d14783555dafcb8bd7b2f2cedef96bbccf657c92cf6abbc9ca9c9"
 
 [[sgx.trusted_files]]
-uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libmbedx509_gramine.so.6"
-sha256 = "edd891d4fa3ea03e941877b52476e2570cf010eda81ca5f3b5e283205e39aeee"
+uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libmbedx509_gramine.so.7"
+sha256 = "c2c15bc12b8d14783555dafcb8bd7b2f2cedef96bbccf657c92cf6abbc9ca9c9"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libmvec.so"
@@ -2794,23 +2809,23 @@ sha256 = "2c6d8df993f8b2a55746d6809785e844d93f16f3d869f7947ae56e1ef964d04f"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libra_tls_attest.so"
-sha256 = "3a135e397013e5e24a06c705456046847ec332c725dceb520bd1d93f96c750a7"
+sha256 = "7b864fbaa987250fb5d33e9268e4d741c4909d8429f91d3f5ad8f274b92e56fc"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libra_tls_verify.a"
-sha256 = "5e86266c1d872fcf4ab338eb5d92873c75f5844676f5656df53885601d4c8ffd"
+sha256 = "422ecf91654513a40e2f6542fe216e08e972c1c803f2da99d4735367ef478a2b"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libra_tls_verify_epid.so"
-sha256 = "025df48f36af5450f5808ab63f62c11afba8f4678b260a952b31a992315ef5ec"
+sha256 = "d0869607eb3fbff26e61efa07c2470a9d3bf90455c998aba498af4a4a27e4292"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libresolv.so"
-sha256 = "a8b4fd502b4999d574a836092f317e3e3ade777c2da885391789266253ea88b7"
+sha256 = "4500da5de30e2a280b9d64f9c4f4e4d6a8822a00f31d747335df538d8d2b4ad1"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libresolv.so.2"
-sha256 = "a8b4fd502b4999d574a836092f317e3e3ade777c2da885391789266253ea88b7"
+sha256 = "4500da5de30e2a280b9d64f9c4f4e4d6a8822a00f31d747335df538d8d2b4ad1"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/librt.so"
@@ -2822,23 +2837,23 @@ sha256 = "92b54ac171256f077fd2ca462cf1a9f56d5644556af09bf11d429dc42dbe59be"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libsecret_prov_attest.so"
-sha256 = "14dd01113b69317643929d4d6474c465bc55c17f8319fdb59714d0540bb37913"
+sha256 = "ba35e227b9c05fcba8724e821e638ce07304caaf774657ae085c5c315d4f156f"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libsecret_prov_verify.a"
-sha256 = "73a39f6f4b6318d51d4cd722cef3e7506e4ddc86a60b36aee1f17a339c2270b2"
+sha256 = "2f65b772de1a0a8546ec6233cacd612a8b28a0028b77b7e151756d9653f960cf"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libsecret_prov_verify_epid.so"
-sha256 = "0e0637c32ece95a53ea933721de7ec511992ae468bbaca4e08b522f5521b374c"
+sha256 = "ad762a6e942aad4535b7f1c2807852d9419873467828f7353ed809e7619f4da8"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libthread_db.so"
-sha256 = "1c0e738795610156e5ede4ae96ef21f437f4e8122520e65a03ffb75135ceca5a"
+sha256 = "98b4e5748274a5a15017dbeb0433a2ce0417612792a691d4b54f67b8a44606dc"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libthread_db.so.1"
-sha256 = "1c0e738795610156e5ede4ae96ef21f437f4e8122520e65a03ffb75135ceca5a"
+sha256 = "98b4e5748274a5a15017dbeb0433a2ce0417612792a691d4b54f67b8a44606dc"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/runtime/glibc/libutil.so"
@@ -2850,11 +2865,11 @@ sha256 = "3583ff82a675adb99acce899a18ec75508478103b436f28cf94a407d7d80e409"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/sgx/libpal.so"
-sha256 = "21971999dac6e1f4b2a334c602aafe8d2882d21705f908edf3f72647dd8362e1"
+sha256 = "262517e81bfc03d95a2f759e6b53ad0201bfed45e3cfecdffd172d52cc9e8f52"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/gramine/sgx/loader"
-sha256 = "ca42fb04902b5966d6a6570da10d54da48b6ddc36f49582bf03d964c911262b5"
+sha256 = "e018bc32831fce9f0d41f2f6b010a4182729048ba4d822f2adee883e83a637cc"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/grcrt1.o"
@@ -4126,11 +4141,11 @@ sha256 = "1d6fe4ba2cd5c69908a5d8b30821964ee1d4fadb3f5563e6c3ce01e4c82b2390"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libapparmor.so.1"
-sha256 = "a2907e43b49b031eacfa5c3b895bc0bed3a9c59c52ab2645062762192a913880"
+sha256 = "38b0a49583fb87e09825e0d8b43c5a18eb7d51684a23a41b23c109d53cbe314b"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libapparmor.so.1.8.2"
-sha256 = "a2907e43b49b031eacfa5c3b895bc0bed3a9c59c52ab2645062762192a913880"
+sha256 = "38b0a49583fb87e09825e0d8b43c5a18eb7d51684a23a41b23c109d53cbe314b"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libappstream.so.0.15.2"
@@ -4142,11 +4157,11 @@ sha256 = "84e2cbe56d2849db023800066c032cb7de68f938bcd43ad772084578e9bb6cb1"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libapr-1.so.0"
-sha256 = "89cc9b80eed594fa595aa13ac1047ea1998dbb68a2921154a7be2a032442f6e4"
+sha256 = "44793195003b31b8d3f6493eb3e4f61e8c827171ce8e84cd55fa6db0857bc9d0"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libapr-1.so.0.7.0"
-sha256 = "89cc9b80eed594fa595aa13ac1047ea1998dbb68a2921154a7be2a032442f6e4"
+sha256 = "44793195003b31b8d3f6493eb3e4f61e8c827171ce8e84cd55fa6db0857bc9d0"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libaprutil-1.so.0"
@@ -4657,6 +4672,10 @@ uri = "file:/usr/lib/x86_64-linux-gnu/libcares.so.2.5.1"
 sha256 = "1a7c8e926288be693425b64e0105eb8b069d8c8665483a132a1a35de067d932b"
 
 [[sgx.trusted_files]]
+uri = "file:/usr/lib/x86_64-linux-gnu/libcbor.a"
+sha256 = "e088297c64c68f3efd06012845aed59f1d75d70543585683cf3e19a275b322d1"
+
+[[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libcbor.so.0.8"
 sha256 = "9a8f9884ac1aca7898b40c60a6cf5708139dffda6554ee88267c6cef84151a83"
 
@@ -4814,27 +4833,27 @@ sha256 = "121fd2908008174acc56cf7e140e85500e525622483a2a1f5ec41f5460ef2f8c"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libcups.so.2"
-sha256 = "3394c265595e99047795aaa9a9fdcf42b123d73a5a7e96c633cd69686a44fc14"
+sha256 = "fa0c54a448840348d398d295b22f1c5d8dbceb09c8a4b1bd3453268cf02e6512"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libcurl-gnutls.so.3"
-sha256 = "034acfdaf05b589aa0dec7072c7e1bf081da6a15178c33896c6e8bd6a4166fc4"
+sha256 = "e133a29c0972cdfe4588102641be3b6d4ec92ca734b558866c815b77ef897ffc"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libcurl-gnutls.so.4"
-sha256 = "034acfdaf05b589aa0dec7072c7e1bf081da6a15178c33896c6e8bd6a4166fc4"
+sha256 = "e133a29c0972cdfe4588102641be3b6d4ec92ca734b558866c815b77ef897ffc"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libcurl-gnutls.so.4.7.0"
-sha256 = "034acfdaf05b589aa0dec7072c7e1bf081da6a15178c33896c6e8bd6a4166fc4"
+sha256 = "e133a29c0972cdfe4588102641be3b6d4ec92ca734b558866c815b77ef897ffc"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libcurl.so.4"
-sha256 = "40794b2ad2271049f6ce0a33bc82ccf4532de55a2aef9bfca21f1dc50a518799"
+sha256 = "75a2bf806a39018e5bb7f0dc8636047850c08f75af90d51a78b957468ea59b86"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libcurl.so.4.7.0"
-sha256 = "40794b2ad2271049f6ce0a33bc82ccf4532de55a2aef9bfca21f1dc50a518799"
+sha256 = "75a2bf806a39018e5bb7f0dc8636047850c08f75af90d51a78b957468ea59b86"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libcurses.a"
@@ -5158,35 +5177,35 @@ sha256 = "447dfcfa8891070f4fd0d039578ed56fb57cf8e2b234831e9ad3beec82880a87"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libexpat.a"
-sha256 = "4a2b3751f43fba7b10612db1d4429c210d6a81c7a336823e9af9d992d475c847"
+sha256 = "ba4af48916ef27ba58f2d8e52b810bb8499562d6a624d49e2f0d3bb116973390"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libexpat.so"
-sha256 = "61635c7c58fe0cdae1abfdd67e6ef1f54d5d162c3a5e45465bede64ef3858e1f"
+sha256 = "5a9bfa7f02613a439b574933a65b28ba5e249c2c1c2349bbbc945edc0021862d"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libexpat.so.1"
-sha256 = "61635c7c58fe0cdae1abfdd67e6ef1f54d5d162c3a5e45465bede64ef3858e1f"
+sha256 = "5a9bfa7f02613a439b574933a65b28ba5e249c2c1c2349bbbc945edc0021862d"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libexpat.so.1.8.7"
-sha256 = "61635c7c58fe0cdae1abfdd67e6ef1f54d5d162c3a5e45465bede64ef3858e1f"
+sha256 = "5a9bfa7f02613a439b574933a65b28ba5e249c2c1c2349bbbc945edc0021862d"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libexpatw.a"
-sha256 = "3e1fd7719fd0397dd6284206c023211746b2f67d224bec9f276be91751ef29d7"
+sha256 = "b7ebcc63fb61ed31f06ecdc6eae11833eb94c3739870a80271d87256b846ff87"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libexpatw.so"
-sha256 = "9426a4839f51cd9ba9816c05401054f1ff5e7c7641b2bbf0ade6ec4cb46c085b"
+sha256 = "ee534f887e1d936a5a0f8e0a774188ffdf31c6447cb36d588996a83730f44802"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libexpatw.so.1"
-sha256 = "9426a4839f51cd9ba9816c05401054f1ff5e7c7641b2bbf0ade6ec4cb46c085b"
+sha256 = "ee534f887e1d936a5a0f8e0a774188ffdf31c6447cb36d588996a83730f44802"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libexpatw.so.1.8.7"
-sha256 = "9426a4839f51cd9ba9816c05401054f1ff5e7c7641b2bbf0ade6ec4cb46c085b"
+sha256 = "ee534f887e1d936a5a0f8e0a774188ffdf31c6447cb36d588996a83730f44802"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libexslt.so.0"
@@ -6482,39 +6501,39 @@ sha256 = "2804f1ae9fd2ed9871788d674b02671caa089efccab2e5aa677a998f216f6e21"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libmbedcrypto_gramine.a"
-sha256 = "31d510cb178921a4c95ac7fc46aa03a34bed145cd6e04998e0c6bb5abad3d5bc"
+sha256 = "598d1f16c625011ea2e0c262865ec0c895c17fc8718615b0fa4d21998cae9233"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libmbedcrypto_gramine.so"
-sha256 = "ab5121fe816d488acb2cd562687785b6108bf381d663c3ccda09ad1128376a53"
+sha256 = "752698bbeec2242538cab4722e503af6adc877338338493eb3bbf3992475de96"
 
 [[sgx.trusted_files]]
-uri = "file:/usr/lib/x86_64-linux-gnu/libmbedcrypto_gramine.so.15"
-sha256 = "ab5121fe816d488acb2cd562687785b6108bf381d663c3ccda09ad1128376a53"
+uri = "file:/usr/lib/x86_64-linux-gnu/libmbedcrypto_gramine.so.16"
+sha256 = "752698bbeec2242538cab4722e503af6adc877338338493eb3bbf3992475de96"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libmbedtls_gramine.a"
-sha256 = "65f0b15b8b6746eff2d6744d31002e920175c671b37556b2f63f8ff0649e58a8"
+sha256 = "350f641c4939e56c5ad69627bc7e2ad59bd1efb74a7006a25af6e56037e7fa42"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libmbedtls_gramine.so"
-sha256 = "4117f196176c05097ac3091c81ef64b44e5c01ec494c5ce88713ec4c94c459b8"
+sha256 = "00aa2b10123dbc05d955448c404a0f013cfc9de06fb02751048c4b6cf32af290"
 
 [[sgx.trusted_files]]
-uri = "file:/usr/lib/x86_64-linux-gnu/libmbedtls_gramine.so.20"
-sha256 = "4117f196176c05097ac3091c81ef64b44e5c01ec494c5ce88713ec4c94c459b8"
+uri = "file:/usr/lib/x86_64-linux-gnu/libmbedtls_gramine.so.21"
+sha256 = "00aa2b10123dbc05d955448c404a0f013cfc9de06fb02751048c4b6cf32af290"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libmbedx509_gramine.a"
-sha256 = "8b7703995327a6bce30a64c801d47fe53e98c1c20f8888bfacc676c2b624eec6"
+sha256 = "00c1bc2f982f3fa7ed5b14d2c1fe4738097f9bb15dd714d01636de94ffbb116a"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libmbedx509_gramine.so"
-sha256 = "edd891d4fa3ea03e941877b52476e2570cf010eda81ca5f3b5e283205e39aeee"
+sha256 = "c2c15bc12b8d14783555dafcb8bd7b2f2cedef96bbccf657c92cf6abbc9ca9c9"
 
 [[sgx.trusted_files]]
-uri = "file:/usr/lib/x86_64-linux-gnu/libmbedx509_gramine.so.6"
-sha256 = "edd891d4fa3ea03e941877b52476e2570cf010eda81ca5f3b5e283205e39aeee"
+uri = "file:/usr/lib/x86_64-linux-gnu/libmbedx509_gramine.so.7"
+sha256 = "c2c15bc12b8d14783555dafcb8bd7b2f2cedef96bbccf657c92cf6abbc9ca9c9"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libmbim-glib.so.4"
@@ -6598,11 +6617,11 @@ sha256 = "f53223a1267e5c36bf41f5fadeb4ffd10f5a6eda342aba544c2f0547fc98d0d5"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libmm-glib.so.0"
-sha256 = "e81f86e282f180c394a6898320bc54aecb75673a38d6a9f4fc2a0eeeefbeb080"
+sha256 = "7b3525ce98761adb08f1e865dd5eeaf534ae7dbf961964e669255a0bacbc263f"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libmm-glib.so.0.9.0"
-sha256 = "e81f86e282f180c394a6898320bc54aecb75673a38d6a9f4fc2a0eeeefbeb080"
+sha256 = "7b3525ce98761adb08f1e865dd5eeaf534ae7dbf961964e669255a0bacbc263f"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libmms.so.0"
@@ -7038,19 +7057,19 @@ sha256 = "c39c76d29ee2b6ef63e81028aba576e255ef24ab41f496141727dc4bb4c14344"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libopenjp2.a"
-sha256 = "9d118b782c4ea364c34d4b49401a1c379b306f4d039c4573e604cd49e9236699"
+sha256 = "232a018921b64d1f314a809d5d3cb791295565ae146bb88abf3e3ff4f6d1566f"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libopenjp2.so"
-sha256 = "2ca9ae0bd8df790b6bb840ca6ad7cd67fdf935b63c53e23aa4ea42546247d505"
+sha256 = "f4978d2700c6b981cae0558e3276b4eca142e2e771fba4df9beb5d2ce3fa08c5"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libopenjp2.so.2.4.0"
-sha256 = "2ca9ae0bd8df790b6bb840ca6ad7cd67fdf935b63c53e23aa4ea42546247d505"
+sha256 = "f4978d2700c6b981cae0558e3276b4eca142e2e771fba4df9beb5d2ce3fa08c5"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libopenjp2.so.7"
-sha256 = "2ca9ae0bd8df790b6bb840ca6ad7cd67fdf935b63c53e23aa4ea42546247d505"
+sha256 = "f4978d2700c6b981cae0558e3276b4eca142e2e771fba4df9beb5d2ce3fa08c5"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libopenjpip_server.a"
@@ -7186,11 +7205,11 @@ sha256 = "55f17cab50b69b608ccb3c377e2a61381175396028c8681d389ca4abe7212b14"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libpcap.so.0.8"
-sha256 = "6b5b06f957140a3c736bd47c6f372f9c18e8282a500aa5d6a232252bbab76099"
+sha256 = "ebce8e76672d672abc462e6bc9affc12a05d29d55514fedc1e50ad7186ea6268"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libpcap.so.1.10.1"
-sha256 = "6b5b06f957140a3c736bd47c6f372f9c18e8282a500aa5d6a232252bbab76099"
+sha256 = "ebce8e76672d672abc462e6bc9affc12a05d29d55514fedc1e50ad7186ea6268"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libpci.so.3"
@@ -7502,19 +7521,19 @@ sha256 = "2eb708fd91b8bcfcfc38807fe6015abb4e37e5e11605a524b2dbd1abe10d07ec"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libpq.a"
-sha256 = "202d0804a39e0d994771ea52d400381455513be5d69df99c9902a3d0ce422f46"
+sha256 = "d723ac851a8e127f4c30797d97100f469f0d7671816dab3f49bc783fc6d2f030"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libpq.so"
-sha256 = "02a57b2cc7d71c1fa42faf5f8595b49ecf0e21d3942c7aa94e1e3e923fe8afad"
+sha256 = "50be47e5a689c3af8ded93e04c6eb1e80fb050ad30debc7c85e23487839e3e5a"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libpq.so.5"
-sha256 = "02a57b2cc7d71c1fa42faf5f8595b49ecf0e21d3942c7aa94e1e3e923fe8afad"
+sha256 = "50be47e5a689c3af8ded93e04c6eb1e80fb050ad30debc7c85e23487839e3e5a"
 
 [[sgx.trusted_files]]
-uri = "file:/usr/lib/x86_64-linux-gnu/libpq.so.5.16"
-sha256 = "02a57b2cc7d71c1fa42faf5f8595b49ecf0e21d3942c7aa94e1e3e923fe8afad"
+uri = "file:/usr/lib/x86_64-linux-gnu/libpq.so.5.17"
+sha256 = "50be47e5a689c3af8ded93e04c6eb1e80fb050ad30debc7c85e23487839e3e5a"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libprocps.so.8"
@@ -7574,19 +7593,19 @@ sha256 = "fdfd7d83a335ba12bd73e857f95a798dae0355f37935231966fd088647978e23"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libpython3.10.a"
-sha256 = "bbffc7cc43ada2359b7090a9d74942c409961861720fcd47cb26e7bb5aedf4f2"
+sha256 = "46cb07cbba10ee28feb943358dac70dc9921fdddf3f01764d9d3fa87946bbdaa"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libpython3.10.so"
-sha256 = "90dbac5c2df831d486b8af7a32fffd0b424fe8cdb869d94b7e3b4781f87aa691"
+sha256 = "961ae7c95f982e4307cce6a4bfd6a61ca5100124e157daf90dcdb1f12a0a3ff4"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libpython3.10.so.1"
-sha256 = "90dbac5c2df831d486b8af7a32fffd0b424fe8cdb869d94b7e3b4781f87aa691"
+sha256 = "961ae7c95f982e4307cce6a4bfd6a61ca5100124e157daf90dcdb1f12a0a3ff4"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libpython3.10.so.1.0"
-sha256 = "90dbac5c2df831d486b8af7a32fffd0b424fe8cdb869d94b7e3b4781f87aa691"
+sha256 = "961ae7c95f982e4307cce6a4bfd6a61ca5100124e157daf90dcdb1f12a0a3ff4"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libqmi-glib.so.5"
@@ -7606,15 +7625,15 @@ sha256 = "1c3f8ec46dccfc4c99d3984ba787bd6d965e2c890089ff885448cb4efc5b1f14"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libra_tls_attest.so"
-sha256 = "3a135e397013e5e24a06c705456046847ec332c725dceb520bd1d93f96c750a7"
+sha256 = "7b864fbaa987250fb5d33e9268e4d741c4909d8429f91d3f5ad8f274b92e56fc"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libra_tls_verify.a"
-sha256 = "5e86266c1d872fcf4ab338eb5d92873c75f5844676f5656df53885601d4c8ffd"
+sha256 = "422ecf91654513a40e2f6542fe216e08e972c1c803f2da99d4735367ef478a2b"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libra_tls_verify_epid.so"
-sha256 = "025df48f36af5450f5808ab63f62c11afba8f4678b260a952b31a992315ef5ec"
+sha256 = "d0869607eb3fbff26e61efa07c2470a9d3bf90455c998aba498af4a4a27e4292"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/librabbitmq.so.4"
@@ -7774,15 +7793,15 @@ sha256 = "596a51073e24172166c26ee459b2794c6506c20f4b5a0fbd806adb228dd3f2ae"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libsecret_prov_attest.so"
-sha256 = "14dd01113b69317643929d4d6474c465bc55c17f8319fdb59714d0540bb37913"
+sha256 = "ba35e227b9c05fcba8724e821e638ce07304caaf774657ae085c5c315d4f156f"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libsecret_prov_verify.a"
-sha256 = "73a39f6f4b6318d51d4cd722cef3e7506e4ddc86a60b36aee1f17a339c2270b2"
+sha256 = "2f65b772de1a0a8546ec6233cacd612a8b28a0028b77b7e151756d9653f960cf"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libsecret_prov_verify_epid.so"
-sha256 = "0e0637c32ece95a53ea933721de7ec511992ae468bbaca4e08b522f5521b374c"
+sha256 = "ad762a6e942aad4535b7f1c2807852d9419873467828f7353ed809e7619f4da8"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libselinux.a"
@@ -7838,7 +7857,7 @@ sha256 = "cb6c0b0d51668d01953cb9742c5bf1d4767bdebdb3e432adc37794abc445dba5"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libsgx_util.a"
-sha256 = "142a8fe1e438ff8d689891904708a8210d0e059afe8b3dd282af33e09924aa88"
+sha256 = "663895d5fb916b18b8afc3a8acebd12f007d865e35a878827ceeb4b0b580dadc"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/libsigsegv.so.2"
@@ -13834,7 +13853,7 @@ sha256 = "d7a389bf7332026f59880157c162116280c4c7506e48a2f4c529886330aebd91"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/pkgconfig/libpq.pc"
-sha256 = "86c5b75cf2d1ec085e561172edc01c85977b895867a8ed54eb080a6fcce67533"
+sha256 = "a6bf469db0ca103fe464c31de58ebbe2bb262cda8d3d24879f0ca2dd667f09da"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/pkgconfig/librsvg-2.0.pc"
@@ -13890,7 +13909,7 @@ sha256 = "07b2deac43966bcde199684131d962bfb40301303f6a6b0eff96df0ffc005448"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/pkgconfig/mbedtls_gramine.pc"
-sha256 = "729d892eb28db52374c180a031f34313cb6295fa20b1e2a8b469c4fb6115f87d"
+sha256 = "21d19b88d5d0890af4d4cdf8c61f7366b2003efe3f442f0dd975dca91fbf97e3"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/pkgconfig/menu.pc"
@@ -13974,7 +13993,7 @@ sha256 = "d8e24143de5d56ff3ee549641a1dfa8816c2280998d0c4154d677f7aaa2d9bba"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/pkgconfig/ra_tls_gramine.pc"
-sha256 = "7f2e3c0dfec3129276302a2f10ca5ca1d5c11c9cb13ed03de671879efa3cfd51"
+sha256 = "36ab04e3e228f007a110e2fc5299087f3ce81ae749fc65c5e82600a5c0520910"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/pkgconfig/readline.pc"
@@ -13990,7 +14009,7 @@ sha256 = "319706f1b4797cd15ad03bd9c276cb79b2619be9d76f3635a908bf665be423ea"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/pkgconfig/secret_prov_gramine.pc"
-sha256 = "b88bec3de8f655e0eb5590508d83d793df6d218b0cc9fe878a511b8dfedc2bf7"
+sha256 = "9bc7f3e4383f796fc81efb2265e8d71c1d81be07deaa619f614c5a5038313ef5"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/x86_64-linux-gnu/pkgconfig/sm.pc"
@@ -15502,7 +15521,7 @@ sha256 = "eddd24c66083d89b1e5bcd4bf3b1930751bf087b0f3e1bde59afd10923892576"
 
 [[sgx.trusted_files]]
 uri = "file:target/release/teleport"
-sha256 = "1ff3fe99fcf191e24fc128a58673ded69e9887be2a194f4bd307f5b0d4bd35c0"
+sha256 = "5a0a150d5683cc28b61ba631509aab6eadabfb8970050b9149932ed572ed3a74"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/ImageMagick-6.9.11/bin-q16/Magick-config"
@@ -18054,15 +18073,15 @@ sha256 = "54ef601588ffd6747497ebf2d8abc97329dcc89ffd995c7b6ef82cdae4b4dd0a"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/direct/libpal.so"
-sha256 = "8edccb9883e04363034ea837d6aa7f38ebffde59c30508666cc8fdf8d23bf291"
+sha256 = "ea140cc8d9caad6ba736b892ddc580444a091a37063d3db501caea4541af8025"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/direct/loader"
-sha256 = "8edccb9883e04363034ea837d6aa7f38ebffde59c30508666cc8fdf8d23bf291"
+sha256 = "ea140cc8d9caad6ba736b892ddc580444a091a37063d3db501caea4541af8025"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/libsysdb.so"
-sha256 = "a9274eba09232700a62b8d604624024c9acea52cca4dc8350fa78ed6fb1e575a"
+sha256 = "8fb2d369e5d67d4d34100464e1b052d18a421860409f3aeef87a0ed9655a85ac"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/crt1.o"
@@ -18078,11 +18097,11 @@ sha256 = "df37c23206d280925216df48eb2d114b283fb28c116e952afe907250e0b89faa"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/ld-linux-x86-64.so.2"
-sha256 = "878d4bd8df7c99e46b5655f176862a1efe97f807256ab44a0f23c05cd2e316d9"
+sha256 = "c5abc02506c12caae024d2fc27af3a1da44934e7f4f8241350f7a476caba25f3"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/ld.so"
-sha256 = "878d4bd8df7c99e46b5655f176862a1efe97f807256ab44a0f23c05cd2e316d9"
+sha256 = "c5abc02506c12caae024d2fc27af3a1da44934e7f4f8241350f7a476caba25f3"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libanl.so"
@@ -18094,11 +18113,11 @@ sha256 = "857e6fac284a297b573489d34e4d6ab2380da96a9df89611cfa7e05a243cc11c"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libc.so"
-sha256 = "b0060a43c7754d56bb91807cd62f724d77883c1009c0d18830071ec2ea074785"
+sha256 = "e282928e943bbde9b4dbabff2d27b332c27a3762f1925d2dc703c17594397b80"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libc.so.6"
-sha256 = "b0060a43c7754d56bb91807cd62f724d77883c1009c0d18830071ec2ea074785"
+sha256 = "e282928e943bbde9b4dbabff2d27b332c27a3762f1925d2dc703c17594397b80"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libdl.so"
@@ -18110,47 +18129,47 @@ sha256 = "b9717d7c65be7e92f9353a2daae1dd89a417a7907398aefd024c77e94920e6c8"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libm.so"
-sha256 = "27abaefc5a51076014908e0ebc131a196577200210254614777bd8d1836f2b71"
+sha256 = "5713649f9c67811bc7a9bb33b6fc545b6b48ac3af023bdbd4a5ef73c38cad2aa"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libm.so.6"
-sha256 = "27abaefc5a51076014908e0ebc131a196577200210254614777bd8d1836f2b71"
+sha256 = "5713649f9c67811bc7a9bb33b6fc545b6b48ac3af023bdbd4a5ef73c38cad2aa"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libmbedcrypto_gramine.a"
-sha256 = "31d510cb178921a4c95ac7fc46aa03a34bed145cd6e04998e0c6bb5abad3d5bc"
+sha256 = "598d1f16c625011ea2e0c262865ec0c895c17fc8718615b0fa4d21998cae9233"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libmbedcrypto_gramine.so"
-sha256 = "ab5121fe816d488acb2cd562687785b6108bf381d663c3ccda09ad1128376a53"
+sha256 = "752698bbeec2242538cab4722e503af6adc877338338493eb3bbf3992475de96"
 
 [[sgx.trusted_files]]
-uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libmbedcrypto_gramine.so.15"
-sha256 = "ab5121fe816d488acb2cd562687785b6108bf381d663c3ccda09ad1128376a53"
+uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libmbedcrypto_gramine.so.16"
+sha256 = "752698bbeec2242538cab4722e503af6adc877338338493eb3bbf3992475de96"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libmbedtls_gramine.a"
-sha256 = "65f0b15b8b6746eff2d6744d31002e920175c671b37556b2f63f8ff0649e58a8"
+sha256 = "350f641c4939e56c5ad69627bc7e2ad59bd1efb74a7006a25af6e56037e7fa42"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libmbedtls_gramine.so"
-sha256 = "4117f196176c05097ac3091c81ef64b44e5c01ec494c5ce88713ec4c94c459b8"
+sha256 = "00aa2b10123dbc05d955448c404a0f013cfc9de06fb02751048c4b6cf32af290"
 
 [[sgx.trusted_files]]
-uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libmbedtls_gramine.so.20"
-sha256 = "4117f196176c05097ac3091c81ef64b44e5c01ec494c5ce88713ec4c94c459b8"
+uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libmbedtls_gramine.so.21"
+sha256 = "00aa2b10123dbc05d955448c404a0f013cfc9de06fb02751048c4b6cf32af290"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libmbedx509_gramine.a"
-sha256 = "8b7703995327a6bce30a64c801d47fe53e98c1c20f8888bfacc676c2b624eec6"
+sha256 = "00c1bc2f982f3fa7ed5b14d2c1fe4738097f9bb15dd714d01636de94ffbb116a"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libmbedx509_gramine.so"
-sha256 = "edd891d4fa3ea03e941877b52476e2570cf010eda81ca5f3b5e283205e39aeee"
+sha256 = "c2c15bc12b8d14783555dafcb8bd7b2f2cedef96bbccf657c92cf6abbc9ca9c9"
 
 [[sgx.trusted_files]]
-uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libmbedx509_gramine.so.6"
-sha256 = "edd891d4fa3ea03e941877b52476e2570cf010eda81ca5f3b5e283205e39aeee"
+uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libmbedx509_gramine.so.7"
+sha256 = "c2c15bc12b8d14783555dafcb8bd7b2f2cedef96bbccf657c92cf6abbc9ca9c9"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libmvec.so"
@@ -18210,23 +18229,23 @@ sha256 = "2c6d8df993f8b2a55746d6809785e844d93f16f3d869f7947ae56e1ef964d04f"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libra_tls_attest.so"
-sha256 = "3a135e397013e5e24a06c705456046847ec332c725dceb520bd1d93f96c750a7"
+sha256 = "7b864fbaa987250fb5d33e9268e4d741c4909d8429f91d3f5ad8f274b92e56fc"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libra_tls_verify.a"
-sha256 = "5e86266c1d872fcf4ab338eb5d92873c75f5844676f5656df53885601d4c8ffd"
+sha256 = "422ecf91654513a40e2f6542fe216e08e972c1c803f2da99d4735367ef478a2b"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libra_tls_verify_epid.so"
-sha256 = "025df48f36af5450f5808ab63f62c11afba8f4678b260a952b31a992315ef5ec"
+sha256 = "d0869607eb3fbff26e61efa07c2470a9d3bf90455c998aba498af4a4a27e4292"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libresolv.so"
-sha256 = "a8b4fd502b4999d574a836092f317e3e3ade777c2da885391789266253ea88b7"
+sha256 = "4500da5de30e2a280b9d64f9c4f4e4d6a8822a00f31d747335df538d8d2b4ad1"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libresolv.so.2"
-sha256 = "a8b4fd502b4999d574a836092f317e3e3ade777c2da885391789266253ea88b7"
+sha256 = "4500da5de30e2a280b9d64f9c4f4e4d6a8822a00f31d747335df538d8d2b4ad1"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/librt.so"
@@ -18238,23 +18257,23 @@ sha256 = "92b54ac171256f077fd2ca462cf1a9f56d5644556af09bf11d429dc42dbe59be"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libsecret_prov_attest.so"
-sha256 = "14dd01113b69317643929d4d6474c465bc55c17f8319fdb59714d0540bb37913"
+sha256 = "ba35e227b9c05fcba8724e821e638ce07304caaf774657ae085c5c315d4f156f"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libsecret_prov_verify.a"
-sha256 = "73a39f6f4b6318d51d4cd722cef3e7506e4ddc86a60b36aee1f17a339c2270b2"
+sha256 = "2f65b772de1a0a8546ec6233cacd612a8b28a0028b77b7e151756d9653f960cf"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libsecret_prov_verify_epid.so"
-sha256 = "0e0637c32ece95a53ea933721de7ec511992ae468bbaca4e08b522f5521b374c"
+sha256 = "ad762a6e942aad4535b7f1c2807852d9419873467828f7353ed809e7619f4da8"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libthread_db.so"
-sha256 = "1c0e738795610156e5ede4ae96ef21f437f4e8122520e65a03ffb75135ceca5a"
+sha256 = "98b4e5748274a5a15017dbeb0433a2ce0417612792a691d4b54f67b8a44606dc"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libthread_db.so.1"
-sha256 = "1c0e738795610156e5ede4ae96ef21f437f4e8122520e65a03ffb75135ceca5a"
+sha256 = "98b4e5748274a5a15017dbeb0433a2ce0417612792a691d4b54f67b8a44606dc"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/runtime/glibc/libutil.so"
@@ -18266,11 +18285,11 @@ sha256 = "3583ff82a675adb99acce899a18ec75508478103b436f28cf94a407d7d80e409"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/sgx/libpal.so"
-sha256 = "21971999dac6e1f4b2a334c602aafe8d2882d21705f908edf3f72647dd8362e1"
+sha256 = "262517e81bfc03d95a2f759e6b53ad0201bfed45e3cfecdffd172d52cc9e8f52"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/gramine/sgx/loader"
-sha256 = "ca42fb04902b5966d6a6570da10d54da48b6ddc36f49582bf03d964c911262b5"
+sha256 = "e018bc32831fce9f0d41f2f6b010a4182729048ba4d822f2adee883e83a637cc"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/grcrt1.o"
@@ -19542,11 +19561,11 @@ sha256 = "1d6fe4ba2cd5c69908a5d8b30821964ee1d4fadb3f5563e6c3ce01e4c82b2390"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libapparmor.so.1"
-sha256 = "a2907e43b49b031eacfa5c3b895bc0bed3a9c59c52ab2645062762192a913880"
+sha256 = "38b0a49583fb87e09825e0d8b43c5a18eb7d51684a23a41b23c109d53cbe314b"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libapparmor.so.1.8.2"
-sha256 = "a2907e43b49b031eacfa5c3b895bc0bed3a9c59c52ab2645062762192a913880"
+sha256 = "38b0a49583fb87e09825e0d8b43c5a18eb7d51684a23a41b23c109d53cbe314b"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libappstream.so.0.15.2"
@@ -19558,11 +19577,11 @@ sha256 = "84e2cbe56d2849db023800066c032cb7de68f938bcd43ad772084578e9bb6cb1"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libapr-1.so.0"
-sha256 = "89cc9b80eed594fa595aa13ac1047ea1998dbb68a2921154a7be2a032442f6e4"
+sha256 = "44793195003b31b8d3f6493eb3e4f61e8c827171ce8e84cd55fa6db0857bc9d0"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libapr-1.so.0.7.0"
-sha256 = "89cc9b80eed594fa595aa13ac1047ea1998dbb68a2921154a7be2a032442f6e4"
+sha256 = "44793195003b31b8d3f6493eb3e4f61e8c827171ce8e84cd55fa6db0857bc9d0"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libaprutil-1.so.0"
@@ -20073,6 +20092,10 @@ uri = "file:/lib/x86_64-linux-gnu/libcares.so.2.5.1"
 sha256 = "1a7c8e926288be693425b64e0105eb8b069d8c8665483a132a1a35de067d932b"
 
 [[sgx.trusted_files]]
+uri = "file:/lib/x86_64-linux-gnu/libcbor.a"
+sha256 = "e088297c64c68f3efd06012845aed59f1d75d70543585683cf3e19a275b322d1"
+
+[[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libcbor.so.0.8"
 sha256 = "9a8f9884ac1aca7898b40c60a6cf5708139dffda6554ee88267c6cef84151a83"
 
@@ -20230,27 +20253,27 @@ sha256 = "121fd2908008174acc56cf7e140e85500e525622483a2a1f5ec41f5460ef2f8c"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libcups.so.2"
-sha256 = "3394c265595e99047795aaa9a9fdcf42b123d73a5a7e96c633cd69686a44fc14"
+sha256 = "fa0c54a448840348d398d295b22f1c5d8dbceb09c8a4b1bd3453268cf02e6512"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libcurl-gnutls.so.3"
-sha256 = "034acfdaf05b589aa0dec7072c7e1bf081da6a15178c33896c6e8bd6a4166fc4"
+sha256 = "e133a29c0972cdfe4588102641be3b6d4ec92ca734b558866c815b77ef897ffc"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libcurl-gnutls.so.4"
-sha256 = "034acfdaf05b589aa0dec7072c7e1bf081da6a15178c33896c6e8bd6a4166fc4"
+sha256 = "e133a29c0972cdfe4588102641be3b6d4ec92ca734b558866c815b77ef897ffc"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libcurl-gnutls.so.4.7.0"
-sha256 = "034acfdaf05b589aa0dec7072c7e1bf081da6a15178c33896c6e8bd6a4166fc4"
+sha256 = "e133a29c0972cdfe4588102641be3b6d4ec92ca734b558866c815b77ef897ffc"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libcurl.so.4"
-sha256 = "40794b2ad2271049f6ce0a33bc82ccf4532de55a2aef9bfca21f1dc50a518799"
+sha256 = "75a2bf806a39018e5bb7f0dc8636047850c08f75af90d51a78b957468ea59b86"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libcurl.so.4.7.0"
-sha256 = "40794b2ad2271049f6ce0a33bc82ccf4532de55a2aef9bfca21f1dc50a518799"
+sha256 = "75a2bf806a39018e5bb7f0dc8636047850c08f75af90d51a78b957468ea59b86"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libcurses.a"
@@ -20574,35 +20597,35 @@ sha256 = "447dfcfa8891070f4fd0d039578ed56fb57cf8e2b234831e9ad3beec82880a87"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libexpat.a"
-sha256 = "4a2b3751f43fba7b10612db1d4429c210d6a81c7a336823e9af9d992d475c847"
+sha256 = "ba4af48916ef27ba58f2d8e52b810bb8499562d6a624d49e2f0d3bb116973390"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libexpat.so"
-sha256 = "61635c7c58fe0cdae1abfdd67e6ef1f54d5d162c3a5e45465bede64ef3858e1f"
+sha256 = "5a9bfa7f02613a439b574933a65b28ba5e249c2c1c2349bbbc945edc0021862d"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libexpat.so.1"
-sha256 = "61635c7c58fe0cdae1abfdd67e6ef1f54d5d162c3a5e45465bede64ef3858e1f"
+sha256 = "5a9bfa7f02613a439b574933a65b28ba5e249c2c1c2349bbbc945edc0021862d"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libexpat.so.1.8.7"
-sha256 = "61635c7c58fe0cdae1abfdd67e6ef1f54d5d162c3a5e45465bede64ef3858e1f"
+sha256 = "5a9bfa7f02613a439b574933a65b28ba5e249c2c1c2349bbbc945edc0021862d"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libexpatw.a"
-sha256 = "3e1fd7719fd0397dd6284206c023211746b2f67d224bec9f276be91751ef29d7"
+sha256 = "b7ebcc63fb61ed31f06ecdc6eae11833eb94c3739870a80271d87256b846ff87"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libexpatw.so"
-sha256 = "9426a4839f51cd9ba9816c05401054f1ff5e7c7641b2bbf0ade6ec4cb46c085b"
+sha256 = "ee534f887e1d936a5a0f8e0a774188ffdf31c6447cb36d588996a83730f44802"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libexpatw.so.1"
-sha256 = "9426a4839f51cd9ba9816c05401054f1ff5e7c7641b2bbf0ade6ec4cb46c085b"
+sha256 = "ee534f887e1d936a5a0f8e0a774188ffdf31c6447cb36d588996a83730f44802"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libexpatw.so.1.8.7"
-sha256 = "9426a4839f51cd9ba9816c05401054f1ff5e7c7641b2bbf0ade6ec4cb46c085b"
+sha256 = "ee534f887e1d936a5a0f8e0a774188ffdf31c6447cb36d588996a83730f44802"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libexslt.so.0"
@@ -21898,39 +21921,39 @@ sha256 = "2804f1ae9fd2ed9871788d674b02671caa089efccab2e5aa677a998f216f6e21"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libmbedcrypto_gramine.a"
-sha256 = "31d510cb178921a4c95ac7fc46aa03a34bed145cd6e04998e0c6bb5abad3d5bc"
+sha256 = "598d1f16c625011ea2e0c262865ec0c895c17fc8718615b0fa4d21998cae9233"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libmbedcrypto_gramine.so"
-sha256 = "ab5121fe816d488acb2cd562687785b6108bf381d663c3ccda09ad1128376a53"
+sha256 = "752698bbeec2242538cab4722e503af6adc877338338493eb3bbf3992475de96"
 
 [[sgx.trusted_files]]
-uri = "file:/lib/x86_64-linux-gnu/libmbedcrypto_gramine.so.15"
-sha256 = "ab5121fe816d488acb2cd562687785b6108bf381d663c3ccda09ad1128376a53"
+uri = "file:/lib/x86_64-linux-gnu/libmbedcrypto_gramine.so.16"
+sha256 = "752698bbeec2242538cab4722e503af6adc877338338493eb3bbf3992475de96"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libmbedtls_gramine.a"
-sha256 = "65f0b15b8b6746eff2d6744d31002e920175c671b37556b2f63f8ff0649e58a8"
+sha256 = "350f641c4939e56c5ad69627bc7e2ad59bd1efb74a7006a25af6e56037e7fa42"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libmbedtls_gramine.so"
-sha256 = "4117f196176c05097ac3091c81ef64b44e5c01ec494c5ce88713ec4c94c459b8"
+sha256 = "00aa2b10123dbc05d955448c404a0f013cfc9de06fb02751048c4b6cf32af290"
 
 [[sgx.trusted_files]]
-uri = "file:/lib/x86_64-linux-gnu/libmbedtls_gramine.so.20"
-sha256 = "4117f196176c05097ac3091c81ef64b44e5c01ec494c5ce88713ec4c94c459b8"
+uri = "file:/lib/x86_64-linux-gnu/libmbedtls_gramine.so.21"
+sha256 = "00aa2b10123dbc05d955448c404a0f013cfc9de06fb02751048c4b6cf32af290"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libmbedx509_gramine.a"
-sha256 = "8b7703995327a6bce30a64c801d47fe53e98c1c20f8888bfacc676c2b624eec6"
+sha256 = "00c1bc2f982f3fa7ed5b14d2c1fe4738097f9bb15dd714d01636de94ffbb116a"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libmbedx509_gramine.so"
-sha256 = "edd891d4fa3ea03e941877b52476e2570cf010eda81ca5f3b5e283205e39aeee"
+sha256 = "c2c15bc12b8d14783555dafcb8bd7b2f2cedef96bbccf657c92cf6abbc9ca9c9"
 
 [[sgx.trusted_files]]
-uri = "file:/lib/x86_64-linux-gnu/libmbedx509_gramine.so.6"
-sha256 = "edd891d4fa3ea03e941877b52476e2570cf010eda81ca5f3b5e283205e39aeee"
+uri = "file:/lib/x86_64-linux-gnu/libmbedx509_gramine.so.7"
+sha256 = "c2c15bc12b8d14783555dafcb8bd7b2f2cedef96bbccf657c92cf6abbc9ca9c9"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libmbim-glib.so.4"
@@ -22014,11 +22037,11 @@ sha256 = "f53223a1267e5c36bf41f5fadeb4ffd10f5a6eda342aba544c2f0547fc98d0d5"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libmm-glib.so.0"
-sha256 = "e81f86e282f180c394a6898320bc54aecb75673a38d6a9f4fc2a0eeeefbeb080"
+sha256 = "7b3525ce98761adb08f1e865dd5eeaf534ae7dbf961964e669255a0bacbc263f"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libmm-glib.so.0.9.0"
-sha256 = "e81f86e282f180c394a6898320bc54aecb75673a38d6a9f4fc2a0eeeefbeb080"
+sha256 = "7b3525ce98761adb08f1e865dd5eeaf534ae7dbf961964e669255a0bacbc263f"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libmms.so.0"
@@ -22454,19 +22477,19 @@ sha256 = "c39c76d29ee2b6ef63e81028aba576e255ef24ab41f496141727dc4bb4c14344"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libopenjp2.a"
-sha256 = "9d118b782c4ea364c34d4b49401a1c379b306f4d039c4573e604cd49e9236699"
+sha256 = "232a018921b64d1f314a809d5d3cb791295565ae146bb88abf3e3ff4f6d1566f"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libopenjp2.so"
-sha256 = "2ca9ae0bd8df790b6bb840ca6ad7cd67fdf935b63c53e23aa4ea42546247d505"
+sha256 = "f4978d2700c6b981cae0558e3276b4eca142e2e771fba4df9beb5d2ce3fa08c5"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libopenjp2.so.2.4.0"
-sha256 = "2ca9ae0bd8df790b6bb840ca6ad7cd67fdf935b63c53e23aa4ea42546247d505"
+sha256 = "f4978d2700c6b981cae0558e3276b4eca142e2e771fba4df9beb5d2ce3fa08c5"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libopenjp2.so.7"
-sha256 = "2ca9ae0bd8df790b6bb840ca6ad7cd67fdf935b63c53e23aa4ea42546247d505"
+sha256 = "f4978d2700c6b981cae0558e3276b4eca142e2e771fba4df9beb5d2ce3fa08c5"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libopenjpip_server.a"
@@ -22602,11 +22625,11 @@ sha256 = "55f17cab50b69b608ccb3c377e2a61381175396028c8681d389ca4abe7212b14"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libpcap.so.0.8"
-sha256 = "6b5b06f957140a3c736bd47c6f372f9c18e8282a500aa5d6a232252bbab76099"
+sha256 = "ebce8e76672d672abc462e6bc9affc12a05d29d55514fedc1e50ad7186ea6268"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libpcap.so.1.10.1"
-sha256 = "6b5b06f957140a3c736bd47c6f372f9c18e8282a500aa5d6a232252bbab76099"
+sha256 = "ebce8e76672d672abc462e6bc9affc12a05d29d55514fedc1e50ad7186ea6268"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libpci.so.3"
@@ -22918,19 +22941,19 @@ sha256 = "2eb708fd91b8bcfcfc38807fe6015abb4e37e5e11605a524b2dbd1abe10d07ec"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libpq.a"
-sha256 = "202d0804a39e0d994771ea52d400381455513be5d69df99c9902a3d0ce422f46"
+sha256 = "d723ac851a8e127f4c30797d97100f469f0d7671816dab3f49bc783fc6d2f030"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libpq.so"
-sha256 = "02a57b2cc7d71c1fa42faf5f8595b49ecf0e21d3942c7aa94e1e3e923fe8afad"
+sha256 = "50be47e5a689c3af8ded93e04c6eb1e80fb050ad30debc7c85e23487839e3e5a"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libpq.so.5"
-sha256 = "02a57b2cc7d71c1fa42faf5f8595b49ecf0e21d3942c7aa94e1e3e923fe8afad"
+sha256 = "50be47e5a689c3af8ded93e04c6eb1e80fb050ad30debc7c85e23487839e3e5a"
 
 [[sgx.trusted_files]]
-uri = "file:/lib/x86_64-linux-gnu/libpq.so.5.16"
-sha256 = "02a57b2cc7d71c1fa42faf5f8595b49ecf0e21d3942c7aa94e1e3e923fe8afad"
+uri = "file:/lib/x86_64-linux-gnu/libpq.so.5.17"
+sha256 = "50be47e5a689c3af8ded93e04c6eb1e80fb050ad30debc7c85e23487839e3e5a"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libprocps.so.8"
@@ -22990,19 +23013,19 @@ sha256 = "fdfd7d83a335ba12bd73e857f95a798dae0355f37935231966fd088647978e23"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libpython3.10.a"
-sha256 = "bbffc7cc43ada2359b7090a9d74942c409961861720fcd47cb26e7bb5aedf4f2"
+sha256 = "46cb07cbba10ee28feb943358dac70dc9921fdddf3f01764d9d3fa87946bbdaa"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libpython3.10.so"
-sha256 = "90dbac5c2df831d486b8af7a32fffd0b424fe8cdb869d94b7e3b4781f87aa691"
+sha256 = "961ae7c95f982e4307cce6a4bfd6a61ca5100124e157daf90dcdb1f12a0a3ff4"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libpython3.10.so.1"
-sha256 = "90dbac5c2df831d486b8af7a32fffd0b424fe8cdb869d94b7e3b4781f87aa691"
+sha256 = "961ae7c95f982e4307cce6a4bfd6a61ca5100124e157daf90dcdb1f12a0a3ff4"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libpython3.10.so.1.0"
-sha256 = "90dbac5c2df831d486b8af7a32fffd0b424fe8cdb869d94b7e3b4781f87aa691"
+sha256 = "961ae7c95f982e4307cce6a4bfd6a61ca5100124e157daf90dcdb1f12a0a3ff4"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libqmi-glib.so.5"
@@ -23022,15 +23045,15 @@ sha256 = "1c3f8ec46dccfc4c99d3984ba787bd6d965e2c890089ff885448cb4efc5b1f14"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libra_tls_attest.so"
-sha256 = "3a135e397013e5e24a06c705456046847ec332c725dceb520bd1d93f96c750a7"
+sha256 = "7b864fbaa987250fb5d33e9268e4d741c4909d8429f91d3f5ad8f274b92e56fc"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libra_tls_verify.a"
-sha256 = "5e86266c1d872fcf4ab338eb5d92873c75f5844676f5656df53885601d4c8ffd"
+sha256 = "422ecf91654513a40e2f6542fe216e08e972c1c803f2da99d4735367ef478a2b"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libra_tls_verify_epid.so"
-sha256 = "025df48f36af5450f5808ab63f62c11afba8f4678b260a952b31a992315ef5ec"
+sha256 = "d0869607eb3fbff26e61efa07c2470a9d3bf90455c998aba498af4a4a27e4292"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/librabbitmq.so.4"
@@ -23190,15 +23213,15 @@ sha256 = "596a51073e24172166c26ee459b2794c6506c20f4b5a0fbd806adb228dd3f2ae"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libsecret_prov_attest.so"
-sha256 = "14dd01113b69317643929d4d6474c465bc55c17f8319fdb59714d0540bb37913"
+sha256 = "ba35e227b9c05fcba8724e821e638ce07304caaf774657ae085c5c315d4f156f"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libsecret_prov_verify.a"
-sha256 = "73a39f6f4b6318d51d4cd722cef3e7506e4ddc86a60b36aee1f17a339c2270b2"
+sha256 = "2f65b772de1a0a8546ec6233cacd612a8b28a0028b77b7e151756d9653f960cf"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libsecret_prov_verify_epid.so"
-sha256 = "0e0637c32ece95a53ea933721de7ec511992ae468bbaca4e08b522f5521b374c"
+sha256 = "ad762a6e942aad4535b7f1c2807852d9419873467828f7353ed809e7619f4da8"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libselinux.a"
@@ -23254,7 +23277,7 @@ sha256 = "cb6c0b0d51668d01953cb9742c5bf1d4767bdebdb3e432adc37794abc445dba5"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libsgx_util.a"
-sha256 = "142a8fe1e438ff8d689891904708a8210d0e059afe8b3dd282af33e09924aa88"
+sha256 = "663895d5fb916b18b8afc3a8acebd12f007d865e35a878827ceeb4b0b580dadc"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/libsigsegv.so.2"
@@ -29250,7 +29273,7 @@ sha256 = "d7a389bf7332026f59880157c162116280c4c7506e48a2f4c529886330aebd91"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/pkgconfig/libpq.pc"
-sha256 = "86c5b75cf2d1ec085e561172edc01c85977b895867a8ed54eb080a6fcce67533"
+sha256 = "a6bf469db0ca103fe464c31de58ebbe2bb262cda8d3d24879f0ca2dd667f09da"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/pkgconfig/librsvg-2.0.pc"
@@ -29306,7 +29329,7 @@ sha256 = "07b2deac43966bcde199684131d962bfb40301303f6a6b0eff96df0ffc005448"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/pkgconfig/mbedtls_gramine.pc"
-sha256 = "729d892eb28db52374c180a031f34313cb6295fa20b1e2a8b469c4fb6115f87d"
+sha256 = "21d19b88d5d0890af4d4cdf8c61f7366b2003efe3f442f0dd975dca91fbf97e3"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/pkgconfig/menu.pc"
@@ -29390,7 +29413,7 @@ sha256 = "d8e24143de5d56ff3ee549641a1dfa8816c2280998d0c4154d677f7aaa2d9bba"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/pkgconfig/ra_tls_gramine.pc"
-sha256 = "7f2e3c0dfec3129276302a2f10ca5ca1d5c11c9cb13ed03de671879efa3cfd51"
+sha256 = "36ab04e3e228f007a110e2fc5299087f3ce81ae749fc65c5e82600a5c0520910"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/pkgconfig/readline.pc"
@@ -29406,7 +29429,7 @@ sha256 = "319706f1b4797cd15ad03bd9c276cb79b2619be9d76f3635a908bf665be423ea"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/pkgconfig/secret_prov_gramine.pc"
-sha256 = "b88bec3de8f655e0eb5590508d83d793df6d218b0cc9fe878a511b8dfedc2bf7"
+sha256 = "9bc7f3e4383f796fc81efb2265e8d71c1d81be07deaa619f614c5a5038313ef5"
 
 [[sgx.trusted_files]]
 uri = "file:/lib/x86_64-linux-gnu/pkgconfig/sm.pc"
@@ -30918,11 +30941,15 @@ sha256 = "eddd24c66083d89b1e5bcd4bf3b1930751bf087b0f3e1bde59afd10923892576"
 
 [[sgx.trusted_files]]
 uri = "file:teleport.env"
-sha256 = "582680885b86e2a986e79662c7e38c08c1bd345bdc88dd2069f3440b0f86ef58"
+sha256 = "76c0b917acb36ef5c135ebb3dc79e1ce52968cee7bff83a6c531f2b3fc72cf74"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/002c0b4f.0"
 sha256 = "dcc1a6246e13880ca5b73ef547e082dd0401e4d8837b6d211be82f7be791ac65"
+
+[[sgx.trusted_files]]
+uri = "file:/usr/lib/ssl/certs/0179095f.0"
+sha256 = "08e1a8115accf7ce400a3f98fc31dbab522a3ed3644ca48389b4899e2d794f1a"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/02265526.0"
@@ -30989,6 +31016,10 @@ uri = "file:/usr/lib/ssl/certs/18856ac4.0"
 sha256 = "20828fd7b9795221c10272f9f6ed29638f6dc2614465adab1b93f2bfc484c659"
 
 [[sgx.trusted_files]]
+uri = "file:/usr/lib/ssl/certs/1cef98f5.0"
+sha256 = "fc9662ebcadeb2c0a804bdb6503d0c23976c638cf73ff95ffafd33ead680e73d"
+
+[[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/1d3472b9.0"
 sha256 = "80eeafa5039f282345129a81ace7e1c1e1d4fd826f1eb3391a4ea56f38a6e3d8"
 
@@ -30999,6 +31030,10 @@ sha256 = "9b4282f5a402e19016c4874a52df3367eabccf05be851ad03039f777a602d30a"
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/1e09d511.0"
 sha256 = "b30989fd9e45c74bf417df74d1da639d1f04d4fd0900be813a2d6a031a56c845"
+
+[[sgx.trusted_files]]
+uri = "file:/usr/lib/ssl/certs/228f89db.0"
+sha256 = "a5e66a87e60e17b9aac2d825c9b898ce4bb635dd6e8a137c0dd2ca761b6165ce"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/244b5494.0"
@@ -31026,15 +31061,11 @@ sha256 = "39fdcf28aeffe08d03251fccaf645e3c5de19fa4ebbafc89b4ede2a422148bab"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/3bde41ac.0"
-sha256 = "283fd555713ed4ecfcb4935f5ed5d4a9bb776236803e2910eb46e70903a3511f"
-
-[[sgx.trusted_files]]
-uri = "file:/usr/lib/ssl/certs/3bde41ac.1"
 sha256 = "a618213c5dd7cbb59b3154de7241d7255333a0619cf434329becae876ce6e331"
 
 [[sgx.trusted_files]]
-uri = "file:/usr/lib/ssl/certs/3e45d192.0"
-sha256 = "9dd93324ad79de9a6d595611342d38ae6ca937772c65e11da3ebf88c5a248115"
+uri = "file:/usr/lib/ssl/certs/3e359ba6.0"
+sha256 = "6c58125f88a4ff83d40e6b58c5532ea905be4daf1ec7da7f4542af3d34855340"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/3fb36b73.0"
@@ -31073,8 +31104,8 @@ uri = "file:/usr/lib/ssl/certs/4f316efb.0"
 sha256 = "0ebb1a5d93b86ad9dcbd294413f272817fe3bb8ba46f4ec8192b3b805f2fa8ae"
 
 [[sgx.trusted_files]]
-uri = "file:/usr/lib/ssl/certs/5273a94c.0"
-sha256 = "789655e3b4c0721faa6a3ffc30853450794fecc5830a12b632261545c3a241bb"
+uri = "file:/usr/lib/ssl/certs/4fd49c6c.0"
+sha256 = "fed2654034ede8dc7677c5e06d4b583bcb0ae352f03cd16111d34c854bbffbbc"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/5443e9e3.0"
@@ -31095,10 +31126,6 @@ sha256 = "ef94d474067b306c482dfd066130f04855f50faecd461cee2964ce6c7260000e"
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/5931b5bc.0"
 sha256 = "0b83e3ece7c33128cc31ac97595ce1bdb524db3f924623093b64e6a96ffb4b9b"
-
-[[sgx.trusted_files]]
-uri = "file:/usr/lib/ssl/certs/5a7722fb.0"
-sha256 = "7aa7e87cb29fb7303d8d2402c98b3855b45859640211773c279f0c046e2071c6"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/5ad8a5d6.0"
@@ -31131,10 +31158,6 @@ sha256 = "1a49076630e489e4b1056804fb6c768397a9de52b236609aaf6ec5b94ce508ec"
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/653b494a.0"
 sha256 = "d1c290ea1e4544dec1934931fbfa1fb2060eb3a0f2239ba191f444ecbce35cbb"
-
-[[sgx.trusted_files]]
-uri = "file:/usr/lib/ssl/certs/66445960.0"
-sha256 = "d96bfedd2e72169afa2cc958f122785a00e5cfc4b860eb8419c3196d99aced34"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/68dd7389.0"
@@ -31193,8 +31216,20 @@ uri = "file:/usr/lib/ssl/certs/8160b96c.0"
 sha256 = "4f670affee7b14140a6d20937db6e991102d5f8bac1d2562ebf20a1afda94d73"
 
 [[sgx.trusted_files]]
+uri = "file:/usr/lib/ssl/certs/81f2d2b1.0"
+sha256 = "80eda3bc1316bbb2c18df887c7a30a40ace97146471337e06bfdd46337a688c3"
+
+[[sgx.trusted_files]]
+uri = "file:/usr/lib/ssl/certs/8312c4c1.0"
+sha256 = "ee459c64139faa1fb8d90a9195022aaca51808c62bb374afa2a26b50875346b1"
+
+[[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/8508e720.0"
 sha256 = "1b28a5568648fef0d3faeb916cb7bdb054724cb3b5a00c6bfd3d8a2fba7a8bba"
+
+[[sgx.trusted_files]]
+uri = "file:/usr/lib/ssl/certs/865fbdf9.0"
+sha256 = "cf03adad817ae999648c5182ac996fc0682aeda4329c783756aa1c5c3d92eff9"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/8cb5ee0f.0"
@@ -31213,6 +31248,10 @@ uri = "file:/usr/lib/ssl/certs/8f103249.0"
 sha256 = "bf3bd189c3dd33bc81635d60284461f0d937c2c1d51cc4d7851c13466419fcb0"
 
 [[sgx.trusted_files]]
+uri = "file:/usr/lib/ssl/certs/9046744a.0"
+sha256 = "7eaaf8c5047d5dbb4f3d7f173318ee936b09da4f0ceb5f3beb45c277480836eb"
+
+[[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/90c5a3c8.0"
 sha256 = "c3f06f635f1939ebeb125e5c1f030e329b63dd808d3ce803b1b1794bc78b253a"
 
@@ -31223,10 +31262,6 @@ sha256 = "c6d25347727f267774611677588d76f8a54a6e14d3e99dd69ef2c20612ed87c5"
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/93bc0acc.0"
 sha256 = "b68109f50ba0abed3b938afebd2ab42a2f5089062c59e9fc74425e2742d894bc"
-
-[[sgx.trusted_files]]
-uri = "file:/usr/lib/ssl/certs/93fee43a.0"
-sha256 = "b8cca1932ff92d62d673216c2874f10667262b6dfc5646213ec0a0d445395d3f"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/9482e63a.0"
@@ -31241,8 +31276,16 @@ uri = "file:/usr/lib/ssl/certs/988a38cb.0"
 sha256 = "40f60f2e2f83fb6c63ddefeba7939a7852b2d468183ea939cc4dcac8fe4cc87d"
 
 [[sgx.trusted_files]]
+uri = "file:/usr/lib/ssl/certs/9b46e03d.0"
+sha256 = "980dc408dd2def2d7930bec10c48e256d115f636c403b631ffb93558dacf5571"
+
+[[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/9b5697b0.0"
 sha256 = "f08c4d2b700f7cd5da4dc1b60f4c57090fdc692cde8a7221f35b70abb4cec363"
+
+[[sgx.trusted_files]]
+uri = "file:/usr/lib/ssl/certs/9bf03295.0"
+sha256 = "d729fda98d8a3bf0d657b93fe0f70e22437359ef0de4ac5b4abcf3ef3667613a"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/9c8dfbd4.0"
@@ -31317,12 +31360,24 @@ uri = "file:/usr/lib/ssl/certs/Atos_TrustedRoot_2011.pem"
 sha256 = "79e9f88ab505186e36f440c88bc37e103e1a9369a0ebe382c4a04bd70b91c027"
 
 [[sgx.trusted_files]]
-uri = "file:/usr/lib/ssl/certs/Autoridad_de_Certificacion_Firmaprofesional_CIF_A62634068.pem"
-sha256 = "283fd555713ed4ecfcb4935f5ed5d4a9bb776236803e2910eb46e70903a3511f"
+uri = "file:/usr/lib/ssl/certs/Atos_TrustedRoot_Root_CA_ECC_TLS_2021.pem"
+sha256 = "970d70366b2f8c29ac71c8f71689ddd8fd321208a5ededbb2d784af33799a0f6"
 
 [[sgx.trusted_files]]
-uri = "file:/usr/lib/ssl/certs/Autoridad_de_Certificacion_Firmaprofesional_CIF_A62634068_2.pem"
+uri = "file:/usr/lib/ssl/certs/Atos_TrustedRoot_Root_CA_RSA_TLS_2021.pem"
+sha256 = "980dc408dd2def2d7930bec10c48e256d115f636c403b631ffb93558dacf5571"
+
+[[sgx.trusted_files]]
+uri = "file:/usr/lib/ssl/certs/Autoridad_de_Certificacion_Firmaprofesional_CIF_A62634068.pem"
 sha256 = "a618213c5dd7cbb59b3154de7241d7255333a0619cf434329becae876ce6e331"
+
+[[sgx.trusted_files]]
+uri = "file:/usr/lib/ssl/certs/BJCA_Global_Root_CA1.pem"
+sha256 = "08e1a8115accf7ce400a3f98fc31dbab522a3ed3644ca48389b4899e2d794f1a"
+
+[[sgx.trusted_files]]
+uri = "file:/usr/lib/ssl/certs/BJCA_Global_Root_CA2.pem"
+sha256 = "6c58125f88a4ff83d40e6b58c5532ea905be4daf1ec7da7f4542af3d34855340"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/Baltimore_CyberTrust_Root.pem"
@@ -31389,6 +31444,22 @@ uri = "file:/usr/lib/ssl/certs/Certum_Trusted_Root_CA.pem"
 sha256 = "e6c62d3f63ba03f4dac458b7dac6c09eb4d71cc3c6621769c3883ed51677c01c"
 
 [[sgx.trusted_files]]
+uri = "file:/usr/lib/ssl/certs/CommScope_Public_Trust_ECC_Root-01.pem"
+sha256 = "a5e66a87e60e17b9aac2d825c9b898ce4bb635dd6e8a137c0dd2ca761b6165ce"
+
+[[sgx.trusted_files]]
+uri = "file:/usr/lib/ssl/certs/CommScope_Public_Trust_ECC_Root-02.pem"
+sha256 = "80eda3bc1316bbb2c18df887c7a30a40ace97146471337e06bfdd46337a688c3"
+
+[[sgx.trusted_files]]
+uri = "file:/usr/lib/ssl/certs/CommScope_Public_Trust_RSA_Root-01.pem"
+sha256 = "ee459c64139faa1fb8d90a9195022aaca51808c62bb374afa2a26b50875346b1"
+
+[[sgx.trusted_files]]
+uri = "file:/usr/lib/ssl/certs/CommScope_Public_Trust_RSA_Root-02.pem"
+sha256 = "fed2654034ede8dc7677c5e06d4b583bcb0ae352f03cd16111d34c854bbffbbc"
+
+[[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/Comodo_AAA_Services_root.pem"
 sha256 = "a5ddabd1602ae1c66ce11ad078e734cc473dcb8e9f573037832d8536ae3de90b"
 
@@ -31447,18 +31518,6 @@ sha256 = "fe64d4b3ae749db5ec57b04ed9203c748fff446f57b9665fad988435d89c9e43"
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/DigiCert_Trusted_Root_G4.pem"
 sha256 = "ce7d6b44f5d510391be98c8d76b18709400a30cd87659bfebe1c6f97ff5181ee"
-
-[[sgx.trusted_files]]
-uri = "file:/usr/lib/ssl/certs/E-Tugra_Certification_Authority.pem"
-sha256 = "789655e3b4c0721faa6a3ffc30853450794fecc5830a12b632261545c3a241bb"
-
-[[sgx.trusted_files]]
-uri = "file:/usr/lib/ssl/certs/E-Tugra_Global_Root_CA_ECC_v3.pem"
-sha256 = "7aa7e87cb29fb7303d8d2402c98b3855b45859640211773c279f0c046e2071c6"
-
-[[sgx.trusted_files]]
-uri = "file:/usr/lib/ssl/certs/E-Tugra_Global_Root_CA_RSA_v3.pem"
-sha256 = "d96bfedd2e72169afa2cc958f122785a00e5cfc4b860eb8419c3196d99aced34"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/Entrust.net_Premium_2048_Secure_Server_CA.pem"
@@ -31561,10 +31620,6 @@ uri = "file:/usr/lib/ssl/certs/HiPKI_Root_CA_-_G1.pem"
 sha256 = "c3f06f635f1939ebeb125e5c1f030e329b63dd808d3ce803b1b1794bc78b253a"
 
 [[sgx.trusted_files]]
-uri = "file:/usr/lib/ssl/certs/Hongkong_Post_Root_CA_1.pem"
-sha256 = "9dd93324ad79de9a6d595611342d38ae6ca937772c65e11da3ebf88c5a248115"
-
-[[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/Hongkong_Post_Root_CA_3.pem"
 sha256 = "1fd9801787f30a4ab835b1462afc3f71473a5eacc74c0a22ed392bc3da9362f3"
 
@@ -31653,8 +31708,24 @@ uri = "file:/usr/lib/ssl/certs/SSL.com_Root_Certification_Authority_RSA.pem"
 sha256 = "2e368debd3626ea9c5d94c582d80050a530b505aa77ba231eb13e4d208c36d67"
 
 [[sgx.trusted_files]]
+uri = "file:/usr/lib/ssl/certs/SSL.com_TLS_ECC_Root_CA_2022.pem"
+sha256 = "cf03adad817ae999648c5182ac996fc0682aeda4329c783756aa1c5c3d92eff9"
+
+[[sgx.trusted_files]]
+uri = "file:/usr/lib/ssl/certs/SSL.com_TLS_RSA_Root_CA_2022.pem"
+sha256 = "e1c93696d4de9125e49f6a12b97a1cbcf8ce7331bc8268f1fe7b6ab447cc14cf"
+
+[[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/SZAFIR_ROOT_CA2.pem"
 sha256 = "cbe8a1eec737c93d1c1cc54e31421f81bf358aa43fbc1ac763d80ce61a17fce0"
+
+[[sgx.trusted_files]]
+uri = "file:/usr/lib/ssl/certs/Sectigo_Public_Server_Authentication_Root_E46.pem"
+sha256 = "808130157f570b7640069852c88e256738007811a64c3aa9a4c31038347dc19c"
+
+[[sgx.trusted_files]]
+uri = "file:/usr/lib/ssl/certs/Sectigo_Public_Server_Authentication_Root_R46.pem"
+sha256 = "7eaaf8c5047d5dbb4f3d7f173318ee936b09da4f0ceb5f3beb45c277480836eb"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/SecureSign_RootCA11.pem"
@@ -31733,6 +31804,14 @@ uri = "file:/usr/lib/ssl/certs/Telia_Root_CA_v2.pem"
 sha256 = "bf3bd189c3dd33bc81635d60284461f0d937c2c1d51cc4d7851c13466419fcb0"
 
 [[sgx.trusted_files]]
+uri = "file:/usr/lib/ssl/certs/TrustAsia_Global_Root_CA_G3.pem"
+sha256 = "d729fda98d8a3bf0d657b93fe0f70e22437359ef0de4ac5b4abcf3ef3667613a"
+
+[[sgx.trusted_files]]
+uri = "file:/usr/lib/ssl/certs/TrustAsia_Global_Root_CA_G4.pem"
+sha256 = "fc9662ebcadeb2c0a804bdb6503d0c23976c638cf73ff95ffafd33ead680e73d"
+
+[[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/Trustwave_Global_Certification_Authority.pem"
 sha256 = "0c7ffc481084cad9ccd3402eba9401b0f5abea0917d985e9ce401c8efbad4b04"
 
@@ -31773,12 +31852,16 @@ uri = "file:/usr/lib/ssl/certs/a3418fda.0"
 sha256 = "7e8b80d078d3dd77d3ed2108dd2b33412c12d7d72cb0965741c70708691776a2"
 
 [[sgx.trusted_files]]
+uri = "file:/usr/lib/ssl/certs/a89d74c2.0"
+sha256 = "e1c93696d4de9125e49f6a12b97a1cbcf8ce7331bc8268f1fe7b6ab447cc14cf"
+
+[[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/a94d09e5.0"
 sha256 = "04846f73d9d0421c60076fd02bad7f0a81a3f11a028d653b0de53290e41dcead"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/adoptium/cacerts"
-sha256 = "518124a7cf28db85b9f6a51cb1b0e31d61d64e8cd108a8ee3b14bda69fcc6d7d"
+sha256 = "286b44e14b4c51ab6450c8a2351657056a59d399ecb8b9d35b3b2095211926cd"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/aee5f10d.0"
@@ -31817,6 +31900,10 @@ uri = "file:/usr/lib/ssl/certs/bf53fb88.0"
 sha256 = "626d330f6a8944fa4245f02f9795668e25a40b29b4cc5206bee73337b7dcd4d5"
 
 [[sgx.trusted_files]]
+uri = "file:/usr/lib/ssl/certs/bff583e5.0"
+sha256 = "0fb15d1a463ebedaa8ea65bf238749231a46dc9cfd2a5f7cbca7484db0bd5d35"
+
+[[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/c01eb047.0"
 sha256 = "de2e7b1bc7a2aed4e5866d3655d1041206c27caf376ee81bfc4012e8225e0e7c"
 
@@ -31826,7 +31913,7 @@ sha256 = "a00b8aa918457f5e7e58457b5e2f80d640fa77cc290572aaab1ae7b4734a9528"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/ca-certificates.crt"
-sha256 = "a05874e84b34854233e5b108db750ebdf06742a000b5f8b30922b101525d3d4e"
+sha256 = "78c6dc58385f66c06265e9d7b155fd02907f51c93c13bdd2b986c641e42a95de"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/ca6e4ad9.0"
@@ -31879,6 +31966,10 @@ sha256 = "8c4220477ed85355fa380466aa8f559106d8a39fc90d3e0c121749e19444064f"
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/d887a5bb.0"
 sha256 = "a83c5b6097b03509711c9cd8de59def7ecf99ed72b4076dc33f5b2e35545b3b3"
+
+[[sgx.trusted_files]]
+uri = "file:/usr/lib/ssl/certs/da0cfd1d.0"
+sha256 = "808130157f570b7640069852c88e256738007811a64c3aa9a4c31038347dc19c"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/dc4d6a89.0"
@@ -32001,6 +32092,10 @@ uri = "file:/usr/lib/ssl/certs/fa5da96b.0"
 sha256 = "b3bcd05e1b177130f6888fcc1cff4e01cff44ef8e6b0d035f04ad6a71dd0879c"
 
 [[sgx.trusted_files]]
+uri = "file:/usr/lib/ssl/certs/fb717492.0"
+sha256 = "970d70366b2f8c29ac71c8f71689ddd8fd321208a5ededbb2d784af33799a0f6"
+
+[[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/fc5a8f99.0"
 sha256 = "8a3dbcb92ab1c6277647fe2ab8536b5c982abbfdb1f1df5728e01b906aba953a"
 
@@ -32022,7 +32117,7 @@ sha256 = "c6904218e180fbfb0ed91d81e892c2dd983c4a3404617cb36aeb3a434c3b9df0"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/ssl-cert-snakeoil.pem"
-sha256 = "b8cca1932ff92d62d673216c2874f10667262b6dfc5646213ec0a0d445395d3f"
+sha256 = "0fb15d1a463ebedaa8ea65bf238749231a46dc9cfd2a5f7cbca7484db0bd5d35"
 
 [[sgx.trusted_files]]
 uri = "file:/usr/lib/ssl/certs/vTrus_ECC_Root_CA.pem"
@@ -32035,6 +32130,10 @@ sha256 = "8cc726cf62c554561e89e1237495bea3026b1709ba7153fed3401fcd489b5aaf"
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/002c0b4f.0"
 sha256 = "dcc1a6246e13880ca5b73ef547e082dd0401e4d8837b6d211be82f7be791ac65"
+
+[[sgx.trusted_files]]
+uri = "file:/etc/ssl/certs/0179095f.0"
+sha256 = "08e1a8115accf7ce400a3f98fc31dbab522a3ed3644ca48389b4899e2d794f1a"
 
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/02265526.0"
@@ -32101,6 +32200,10 @@ uri = "file:/etc/ssl/certs/18856ac4.0"
 sha256 = "20828fd7b9795221c10272f9f6ed29638f6dc2614465adab1b93f2bfc484c659"
 
 [[sgx.trusted_files]]
+uri = "file:/etc/ssl/certs/1cef98f5.0"
+sha256 = "fc9662ebcadeb2c0a804bdb6503d0c23976c638cf73ff95ffafd33ead680e73d"
+
+[[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/1d3472b9.0"
 sha256 = "80eeafa5039f282345129a81ace7e1c1e1d4fd826f1eb3391a4ea56f38a6e3d8"
 
@@ -32111,6 +32214,10 @@ sha256 = "9b4282f5a402e19016c4874a52df3367eabccf05be851ad03039f777a602d30a"
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/1e09d511.0"
 sha256 = "b30989fd9e45c74bf417df74d1da639d1f04d4fd0900be813a2d6a031a56c845"
+
+[[sgx.trusted_files]]
+uri = "file:/etc/ssl/certs/228f89db.0"
+sha256 = "a5e66a87e60e17b9aac2d825c9b898ce4bb635dd6e8a137c0dd2ca761b6165ce"
 
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/244b5494.0"
@@ -32138,15 +32245,11 @@ sha256 = "39fdcf28aeffe08d03251fccaf645e3c5de19fa4ebbafc89b4ede2a422148bab"
 
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/3bde41ac.0"
-sha256 = "283fd555713ed4ecfcb4935f5ed5d4a9bb776236803e2910eb46e70903a3511f"
-
-[[sgx.trusted_files]]
-uri = "file:/etc/ssl/certs/3bde41ac.1"
 sha256 = "a618213c5dd7cbb59b3154de7241d7255333a0619cf434329becae876ce6e331"
 
 [[sgx.trusted_files]]
-uri = "file:/etc/ssl/certs/3e45d192.0"
-sha256 = "9dd93324ad79de9a6d595611342d38ae6ca937772c65e11da3ebf88c5a248115"
+uri = "file:/etc/ssl/certs/3e359ba6.0"
+sha256 = "6c58125f88a4ff83d40e6b58c5532ea905be4daf1ec7da7f4542af3d34855340"
 
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/3fb36b73.0"
@@ -32185,8 +32288,8 @@ uri = "file:/etc/ssl/certs/4f316efb.0"
 sha256 = "0ebb1a5d93b86ad9dcbd294413f272817fe3bb8ba46f4ec8192b3b805f2fa8ae"
 
 [[sgx.trusted_files]]
-uri = "file:/etc/ssl/certs/5273a94c.0"
-sha256 = "789655e3b4c0721faa6a3ffc30853450794fecc5830a12b632261545c3a241bb"
+uri = "file:/etc/ssl/certs/4fd49c6c.0"
+sha256 = "fed2654034ede8dc7677c5e06d4b583bcb0ae352f03cd16111d34c854bbffbbc"
 
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/5443e9e3.0"
@@ -32207,10 +32310,6 @@ sha256 = "ef94d474067b306c482dfd066130f04855f50faecd461cee2964ce6c7260000e"
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/5931b5bc.0"
 sha256 = "0b83e3ece7c33128cc31ac97595ce1bdb524db3f924623093b64e6a96ffb4b9b"
-
-[[sgx.trusted_files]]
-uri = "file:/etc/ssl/certs/5a7722fb.0"
-sha256 = "7aa7e87cb29fb7303d8d2402c98b3855b45859640211773c279f0c046e2071c6"
 
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/5ad8a5d6.0"
@@ -32243,10 +32342,6 @@ sha256 = "1a49076630e489e4b1056804fb6c768397a9de52b236609aaf6ec5b94ce508ec"
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/653b494a.0"
 sha256 = "d1c290ea1e4544dec1934931fbfa1fb2060eb3a0f2239ba191f444ecbce35cbb"
-
-[[sgx.trusted_files]]
-uri = "file:/etc/ssl/certs/66445960.0"
-sha256 = "d96bfedd2e72169afa2cc958f122785a00e5cfc4b860eb8419c3196d99aced34"
 
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/68dd7389.0"
@@ -32305,8 +32400,20 @@ uri = "file:/etc/ssl/certs/8160b96c.0"
 sha256 = "4f670affee7b14140a6d20937db6e991102d5f8bac1d2562ebf20a1afda94d73"
 
 [[sgx.trusted_files]]
+uri = "file:/etc/ssl/certs/81f2d2b1.0"
+sha256 = "80eda3bc1316bbb2c18df887c7a30a40ace97146471337e06bfdd46337a688c3"
+
+[[sgx.trusted_files]]
+uri = "file:/etc/ssl/certs/8312c4c1.0"
+sha256 = "ee459c64139faa1fb8d90a9195022aaca51808c62bb374afa2a26b50875346b1"
+
+[[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/8508e720.0"
 sha256 = "1b28a5568648fef0d3faeb916cb7bdb054724cb3b5a00c6bfd3d8a2fba7a8bba"
+
+[[sgx.trusted_files]]
+uri = "file:/etc/ssl/certs/865fbdf9.0"
+sha256 = "cf03adad817ae999648c5182ac996fc0682aeda4329c783756aa1c5c3d92eff9"
 
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/8cb5ee0f.0"
@@ -32325,6 +32432,10 @@ uri = "file:/etc/ssl/certs/8f103249.0"
 sha256 = "bf3bd189c3dd33bc81635d60284461f0d937c2c1d51cc4d7851c13466419fcb0"
 
 [[sgx.trusted_files]]
+uri = "file:/etc/ssl/certs/9046744a.0"
+sha256 = "7eaaf8c5047d5dbb4f3d7f173318ee936b09da4f0ceb5f3beb45c277480836eb"
+
+[[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/90c5a3c8.0"
 sha256 = "c3f06f635f1939ebeb125e5c1f030e329b63dd808d3ce803b1b1794bc78b253a"
 
@@ -32335,10 +32446,6 @@ sha256 = "c6d25347727f267774611677588d76f8a54a6e14d3e99dd69ef2c20612ed87c5"
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/93bc0acc.0"
 sha256 = "b68109f50ba0abed3b938afebd2ab42a2f5089062c59e9fc74425e2742d894bc"
-
-[[sgx.trusted_files]]
-uri = "file:/etc/ssl/certs/93fee43a.0"
-sha256 = "b8cca1932ff92d62d673216c2874f10667262b6dfc5646213ec0a0d445395d3f"
 
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/9482e63a.0"
@@ -32353,8 +32460,16 @@ uri = "file:/etc/ssl/certs/988a38cb.0"
 sha256 = "40f60f2e2f83fb6c63ddefeba7939a7852b2d468183ea939cc4dcac8fe4cc87d"
 
 [[sgx.trusted_files]]
+uri = "file:/etc/ssl/certs/9b46e03d.0"
+sha256 = "980dc408dd2def2d7930bec10c48e256d115f636c403b631ffb93558dacf5571"
+
+[[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/9b5697b0.0"
 sha256 = "f08c4d2b700f7cd5da4dc1b60f4c57090fdc692cde8a7221f35b70abb4cec363"
+
+[[sgx.trusted_files]]
+uri = "file:/etc/ssl/certs/9bf03295.0"
+sha256 = "d729fda98d8a3bf0d657b93fe0f70e22437359ef0de4ac5b4abcf3ef3667613a"
 
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/9c8dfbd4.0"
@@ -32429,12 +32544,24 @@ uri = "file:/etc/ssl/certs/Atos_TrustedRoot_2011.pem"
 sha256 = "79e9f88ab505186e36f440c88bc37e103e1a9369a0ebe382c4a04bd70b91c027"
 
 [[sgx.trusted_files]]
-uri = "file:/etc/ssl/certs/Autoridad_de_Certificacion_Firmaprofesional_CIF_A62634068.pem"
-sha256 = "283fd555713ed4ecfcb4935f5ed5d4a9bb776236803e2910eb46e70903a3511f"
+uri = "file:/etc/ssl/certs/Atos_TrustedRoot_Root_CA_ECC_TLS_2021.pem"
+sha256 = "970d70366b2f8c29ac71c8f71689ddd8fd321208a5ededbb2d784af33799a0f6"
 
 [[sgx.trusted_files]]
-uri = "file:/etc/ssl/certs/Autoridad_de_Certificacion_Firmaprofesional_CIF_A62634068_2.pem"
+uri = "file:/etc/ssl/certs/Atos_TrustedRoot_Root_CA_RSA_TLS_2021.pem"
+sha256 = "980dc408dd2def2d7930bec10c48e256d115f636c403b631ffb93558dacf5571"
+
+[[sgx.trusted_files]]
+uri = "file:/etc/ssl/certs/Autoridad_de_Certificacion_Firmaprofesional_CIF_A62634068.pem"
 sha256 = "a618213c5dd7cbb59b3154de7241d7255333a0619cf434329becae876ce6e331"
+
+[[sgx.trusted_files]]
+uri = "file:/etc/ssl/certs/BJCA_Global_Root_CA1.pem"
+sha256 = "08e1a8115accf7ce400a3f98fc31dbab522a3ed3644ca48389b4899e2d794f1a"
+
+[[sgx.trusted_files]]
+uri = "file:/etc/ssl/certs/BJCA_Global_Root_CA2.pem"
+sha256 = "6c58125f88a4ff83d40e6b58c5532ea905be4daf1ec7da7f4542af3d34855340"
 
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/Baltimore_CyberTrust_Root.pem"
@@ -32501,6 +32628,22 @@ uri = "file:/etc/ssl/certs/Certum_Trusted_Root_CA.pem"
 sha256 = "e6c62d3f63ba03f4dac458b7dac6c09eb4d71cc3c6621769c3883ed51677c01c"
 
 [[sgx.trusted_files]]
+uri = "file:/etc/ssl/certs/CommScope_Public_Trust_ECC_Root-01.pem"
+sha256 = "a5e66a87e60e17b9aac2d825c9b898ce4bb635dd6e8a137c0dd2ca761b6165ce"
+
+[[sgx.trusted_files]]
+uri = "file:/etc/ssl/certs/CommScope_Public_Trust_ECC_Root-02.pem"
+sha256 = "80eda3bc1316bbb2c18df887c7a30a40ace97146471337e06bfdd46337a688c3"
+
+[[sgx.trusted_files]]
+uri = "file:/etc/ssl/certs/CommScope_Public_Trust_RSA_Root-01.pem"
+sha256 = "ee459c64139faa1fb8d90a9195022aaca51808c62bb374afa2a26b50875346b1"
+
+[[sgx.trusted_files]]
+uri = "file:/etc/ssl/certs/CommScope_Public_Trust_RSA_Root-02.pem"
+sha256 = "fed2654034ede8dc7677c5e06d4b583bcb0ae352f03cd16111d34c854bbffbbc"
+
+[[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/Comodo_AAA_Services_root.pem"
 sha256 = "a5ddabd1602ae1c66ce11ad078e734cc473dcb8e9f573037832d8536ae3de90b"
 
@@ -32559,18 +32702,6 @@ sha256 = "fe64d4b3ae749db5ec57b04ed9203c748fff446f57b9665fad988435d89c9e43"
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/DigiCert_Trusted_Root_G4.pem"
 sha256 = "ce7d6b44f5d510391be98c8d76b18709400a30cd87659bfebe1c6f97ff5181ee"
-
-[[sgx.trusted_files]]
-uri = "file:/etc/ssl/certs/E-Tugra_Certification_Authority.pem"
-sha256 = "789655e3b4c0721faa6a3ffc30853450794fecc5830a12b632261545c3a241bb"
-
-[[sgx.trusted_files]]
-uri = "file:/etc/ssl/certs/E-Tugra_Global_Root_CA_ECC_v3.pem"
-sha256 = "7aa7e87cb29fb7303d8d2402c98b3855b45859640211773c279f0c046e2071c6"
-
-[[sgx.trusted_files]]
-uri = "file:/etc/ssl/certs/E-Tugra_Global_Root_CA_RSA_v3.pem"
-sha256 = "d96bfedd2e72169afa2cc958f122785a00e5cfc4b860eb8419c3196d99aced34"
 
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/Entrust.net_Premium_2048_Secure_Server_CA.pem"
@@ -32673,10 +32804,6 @@ uri = "file:/etc/ssl/certs/HiPKI_Root_CA_-_G1.pem"
 sha256 = "c3f06f635f1939ebeb125e5c1f030e329b63dd808d3ce803b1b1794bc78b253a"
 
 [[sgx.trusted_files]]
-uri = "file:/etc/ssl/certs/Hongkong_Post_Root_CA_1.pem"
-sha256 = "9dd93324ad79de9a6d595611342d38ae6ca937772c65e11da3ebf88c5a248115"
-
-[[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/Hongkong_Post_Root_CA_3.pem"
 sha256 = "1fd9801787f30a4ab835b1462afc3f71473a5eacc74c0a22ed392bc3da9362f3"
 
@@ -32765,8 +32892,24 @@ uri = "file:/etc/ssl/certs/SSL.com_Root_Certification_Authority_RSA.pem"
 sha256 = "2e368debd3626ea9c5d94c582d80050a530b505aa77ba231eb13e4d208c36d67"
 
 [[sgx.trusted_files]]
+uri = "file:/etc/ssl/certs/SSL.com_TLS_ECC_Root_CA_2022.pem"
+sha256 = "cf03adad817ae999648c5182ac996fc0682aeda4329c783756aa1c5c3d92eff9"
+
+[[sgx.trusted_files]]
+uri = "file:/etc/ssl/certs/SSL.com_TLS_RSA_Root_CA_2022.pem"
+sha256 = "e1c93696d4de9125e49f6a12b97a1cbcf8ce7331bc8268f1fe7b6ab447cc14cf"
+
+[[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/SZAFIR_ROOT_CA2.pem"
 sha256 = "cbe8a1eec737c93d1c1cc54e31421f81bf358aa43fbc1ac763d80ce61a17fce0"
+
+[[sgx.trusted_files]]
+uri = "file:/etc/ssl/certs/Sectigo_Public_Server_Authentication_Root_E46.pem"
+sha256 = "808130157f570b7640069852c88e256738007811a64c3aa9a4c31038347dc19c"
+
+[[sgx.trusted_files]]
+uri = "file:/etc/ssl/certs/Sectigo_Public_Server_Authentication_Root_R46.pem"
+sha256 = "7eaaf8c5047d5dbb4f3d7f173318ee936b09da4f0ceb5f3beb45c277480836eb"
 
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/SecureSign_RootCA11.pem"
@@ -32845,6 +32988,14 @@ uri = "file:/etc/ssl/certs/Telia_Root_CA_v2.pem"
 sha256 = "bf3bd189c3dd33bc81635d60284461f0d937c2c1d51cc4d7851c13466419fcb0"
 
 [[sgx.trusted_files]]
+uri = "file:/etc/ssl/certs/TrustAsia_Global_Root_CA_G3.pem"
+sha256 = "d729fda98d8a3bf0d657b93fe0f70e22437359ef0de4ac5b4abcf3ef3667613a"
+
+[[sgx.trusted_files]]
+uri = "file:/etc/ssl/certs/TrustAsia_Global_Root_CA_G4.pem"
+sha256 = "fc9662ebcadeb2c0a804bdb6503d0c23976c638cf73ff95ffafd33ead680e73d"
+
+[[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/Trustwave_Global_Certification_Authority.pem"
 sha256 = "0c7ffc481084cad9ccd3402eba9401b0f5abea0917d985e9ce401c8efbad4b04"
 
@@ -32885,12 +33036,16 @@ uri = "file:/etc/ssl/certs/a3418fda.0"
 sha256 = "7e8b80d078d3dd77d3ed2108dd2b33412c12d7d72cb0965741c70708691776a2"
 
 [[sgx.trusted_files]]
+uri = "file:/etc/ssl/certs/a89d74c2.0"
+sha256 = "e1c93696d4de9125e49f6a12b97a1cbcf8ce7331bc8268f1fe7b6ab447cc14cf"
+
+[[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/a94d09e5.0"
 sha256 = "04846f73d9d0421c60076fd02bad7f0a81a3f11a028d653b0de53290e41dcead"
 
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/adoptium/cacerts"
-sha256 = "518124a7cf28db85b9f6a51cb1b0e31d61d64e8cd108a8ee3b14bda69fcc6d7d"
+sha256 = "286b44e14b4c51ab6450c8a2351657056a59d399ecb8b9d35b3b2095211926cd"
 
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/aee5f10d.0"
@@ -32929,6 +33084,10 @@ uri = "file:/etc/ssl/certs/bf53fb88.0"
 sha256 = "626d330f6a8944fa4245f02f9795668e25a40b29b4cc5206bee73337b7dcd4d5"
 
 [[sgx.trusted_files]]
+uri = "file:/etc/ssl/certs/bff583e5.0"
+sha256 = "0fb15d1a463ebedaa8ea65bf238749231a46dc9cfd2a5f7cbca7484db0bd5d35"
+
+[[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/c01eb047.0"
 sha256 = "de2e7b1bc7a2aed4e5866d3655d1041206c27caf376ee81bfc4012e8225e0e7c"
 
@@ -32938,7 +33097,7 @@ sha256 = "a00b8aa918457f5e7e58457b5e2f80d640fa77cc290572aaab1ae7b4734a9528"
 
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/ca-certificates.crt"
-sha256 = "a05874e84b34854233e5b108db750ebdf06742a000b5f8b30922b101525d3d4e"
+sha256 = "78c6dc58385f66c06265e9d7b155fd02907f51c93c13bdd2b986c641e42a95de"
 
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/ca6e4ad9.0"
@@ -32991,6 +33150,10 @@ sha256 = "8c4220477ed85355fa380466aa8f559106d8a39fc90d3e0c121749e19444064f"
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/d887a5bb.0"
 sha256 = "a83c5b6097b03509711c9cd8de59def7ecf99ed72b4076dc33f5b2e35545b3b3"
+
+[[sgx.trusted_files]]
+uri = "file:/etc/ssl/certs/da0cfd1d.0"
+sha256 = "808130157f570b7640069852c88e256738007811a64c3aa9a4c31038347dc19c"
 
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/dc4d6a89.0"
@@ -33113,6 +33276,10 @@ uri = "file:/etc/ssl/certs/fa5da96b.0"
 sha256 = "b3bcd05e1b177130f6888fcc1cff4e01cff44ef8e6b0d035f04ad6a71dd0879c"
 
 [[sgx.trusted_files]]
+uri = "file:/etc/ssl/certs/fb717492.0"
+sha256 = "970d70366b2f8c29ac71c8f71689ddd8fd321208a5ededbb2d784af33799a0f6"
+
+[[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/fc5a8f99.0"
 sha256 = "8a3dbcb92ab1c6277647fe2ab8536b5c982abbfdb1f1df5728e01b906aba953a"
 
@@ -33134,7 +33301,7 @@ sha256 = "c6904218e180fbfb0ed91d81e892c2dd983c4a3404617cb36aeb3a434c3b9df0"
 
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/ssl-cert-snakeoil.pem"
-sha256 = "b8cca1932ff92d62d673216c2874f10667262b6dfc5646213ec0a0d445395d3f"
+sha256 = "0fb15d1a463ebedaa8ea65bf238749231a46dc9cfd2a5f7cbca7484db0bd5d35"
 
 [[sgx.trusted_files]]
 uri = "file:/etc/ssl/certs/vTrus_ECC_Root_CA.pem"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,80 @@
+{
+  "nodes": {
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1710156097,
+        "narHash": "sha256-1Wvk8UP7PXdf8bCCaEoMnOT1qe5/Duqgj+rL8sRQsSM=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "3342559a24e85fc164b295c3444e8a139924675b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "3342559a24e85fc164b295c3444e8a139924675b",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1717179513,
+        "narHash": "sha256-vboIEwIQojofItm2xGCdZCzW96U85l9nDW3ifMuAIdM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "63dacb46bf939521bdc93981b4cbb7ecb58427a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "63dacb46bf939521bdc93981b4cbb7ecb58427a0",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1728538411,
+        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nix-filter": "nix-filter",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1729736953,
+        "narHash": "sha256-Rb6JUop7NRklg0uzcre+A+Ebrn/ZiQPkm4QdKg6/3pw=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "29b1275740d9283467b8117499ec8cbb35250584",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "29b1275740d9283467b8117499ec8cbb35250584",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,100 @@
+{
+  description = "teleport";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?rev=63dacb46bf939521bdc93981b4cbb7ecb58427a0";
+    rust-overlay.url = "github:oxalica/rust-overlay?rev=29b1275740d9283467b8117499ec8cbb35250584";
+    nix-filter.url = "github:numtide/nix-filter?rev=3342559a24e85fc164b295c3444e8a139924675b";
+  };
+
+  outputs = { self, nixpkgs, rust-overlay, nix-filter }:
+    let
+      allSystems = [
+        "x86_64-linux" # 64-bit Intel/AMD Linux
+      ];
+
+      forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            rust-overlay.overlays.default
+            self.overlays.default
+          ];
+        };
+      });
+      filter = nix-filter.lib;
+    in
+    {
+      overlays.default = final: prev: {
+        rustToolchain = final.rust-bin.stable.latest.default;
+        #rustToolchain = final.rust-bin.fromRustupToolchainFile ./rust-toolchain;
+      };
+
+      packages = forAllSystems ({ pkgs }: {
+        default =
+          let
+            rustPlatform = pkgs.makeRustPlatform {
+              cargo = pkgs.rustToolchain;
+              rustc = pkgs.rustToolchain;
+            };
+          in
+          rustPlatform.buildRustPackage {
+            name = "teleport";
+            version = "0.1.0";
+            src = filter {
+              root = ./.;
+              include = [
+                ./Cargo.toml
+                ./Cargo.lock
+                ./rust-toolchain
+                ./src
+                ./abi
+                ./templates
+              ];
+              exclude = [
+                ./src/bin/redeem.rs
+              ];
+            };
+            doCheck = false;
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+              # NOTE for git deps, the outputhash must be specified
+              #
+              #outputHashes = {
+              #  "alloy-0.4.2" = pkgs.lib.fakeSha256;
+              #};
+              #
+              # OR set:
+              #
+              #allowBuiltinFetchGit = true;
+              #
+              # see https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/rust.section.md#importing-a-cargolock-file-importing-a-cargolock-file
+            };
+
+            nativeBuildInputs = with pkgs; [
+              pkg-config
+            ];
+            buildInputs = with pkgs; [
+              openssl
+            ];
+
+          };
+        });
+
+      devShells = forAllSystems ({ pkgs }: {
+        default = pkgs.mkShell {
+          packages = (with pkgs; [
+            rustToolchain
+          ]);
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+          ];
+          buildInputs = with pkgs; [
+            diffoscope
+            openssl
+          ];
+        };
+      });
+
+    };
+}


### PR DESCRIPTION
Adds a `flake.nix` file to build the `teleport` binary, which is passed to `gramine-manifest`. Hence, this replaces `cargo build --release`, or rather is now done through `nix`.

For convenience, a stage in the Dockerfile is added to build the `teleport` binary, which is copied over in the gramine-based image.

The cargo-based build was left in the Dockerfile has it may be useful for development purposes, and it is also sped up with [`cargo-chef`](https://github.com/LukeMathWalker/cargo-chef). 

A [github workflow](https://github.com/sbellem/teleport-gramine-rs/actions/runs/11537661307) was added to check the expected hash of the `teleport binary`. The workflow builds teleport in two ways: 1) with [nix on ubuntu](https://github.com/sbellem/teleport-gramine-rs/actions/runs/11537661307/job/32115312265#step:7:5), and 2) with [nix in docker](https://github.com/sbellem/teleport-gramine-rs/actions/runs/11537661307/job/32115312191#step:5:5).

The docker-compose file was modified to allow building sandboxed nix packages in docker.


See [`REPRO_BUILD.md`](https://github.com/Account-Link/teleport-gramine-rs/blob/1cea48313003a567fb8a08f3205c14f3490d0e92/REPRO_BUILDS.md) for more information..
